### PR TITLE
Fix PDF preview fallback

### DIFF
--- a/src/pages/ExperiencePage.css
+++ b/src/pages/ExperiencePage.css
@@ -335,6 +335,16 @@
   color: var(--primary);
 }
 
+/* fallback when PDF embedding isn’t supported */
+.no-preview-wrapper {
+  text-align: center;
+  margin: 2rem 0;
+}
+.no-preview-wrapper .download-report-btn {
+  display: inline-block;
+  margin-top: 1.5rem;
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;

--- a/src/pages/ExperiencePage.jsx
+++ b/src/pages/ExperiencePage.jsx
@@ -229,10 +229,18 @@ const ExperiencePage = () => {
                         style={{ width: '100%', height: '60vh', border: 'none' }}
                       />
                     ) : (
-                      <p className="no-preview">
-                        Your browser can’t display PDFs inline.  
-                        Use the button below to download the report.
-                      </p>
+                      <div className="no-preview-wrapper">
+                        <p className="no-preview">
+                          Your browser can’t display PDFs inline.
+                        </p>
+                        <a
+                          href={selectedProject.reportFile}
+                          download
+                          className="button outline download-report-btn"
+                        >
+                          Download Report
+                        </a>
+                      </div>
                     )
                   }
                 </div>


### PR DESCRIPTION
## Summary
- let ExperiencePage offer PDF download when no preview is available
- style the new download link in ExperiencePage

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528be04d308322839bec45a9a75b2e