### PR TITLE
Fix className expression

### DIFF
--- a/src/pages/CertificationsPage.jsx
+++ b/src/pages/CertificationsPage.jsx
@@ -332,7 +332,7 @@ const CertificationsPage = () => {
                     })}
                     { certificate.status === 'In Progress' ? ' (Expected Finish Date)' : ''}
                   </p>
-                  <p className={`certificate-${certificate.status===`In Progress`?`ongoing`: `completed`}`}>{certificate.status}</p>
+                  <p className={'certificate-' + (certificate.status === 'In Progress' ? 'ongoing' : 'completed')}>{certificate.status}</p>
                   <span className="certificate-category">{certificate.category}</span>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- use single quotes for certificate status class

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528d13778483228506ad0be3b6f363