### PR TITLE
Remove unused swiper dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "react-icons": "^4.12.0",
         "react-router-dom": "^6.21.1",
         "react-scripts": "5.0.1",
-        "swiper": "^11.2.8",
         "web-vitals": "^2.1.4"
       }
     },
@@ -15737,25 +15736,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/swiper": {
-      "version": "11.2.8",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.8.tgz",
-      "integrity": "sha512-S5FVf6zWynPWooi7pJ7lZhSUe2snTzqLuUzbd5h5PHUOhzgvW0bLKBd2wv0ixn6/5o9vwc/IkQT74CRcLJQzeg==",
-      "funding": [
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
-        },
-        {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.7.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "react-icons": "^4.12.0",
     "react-router-dom": "^6.21.1",
     "react-scripts": "5.0.1",
-    "swiper": "^11.2.8",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/pages/CertificationsPage.js
+++ b/src/pages/CertificationsPage.js
@@ -1,10 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import './CertificationsPage.css';
-import { Swiper, SwiperSlide } from 'swiper/react';
-import 'swiper/css';
-import 'swiper/css/pagination';
-import { Pagination } from 'swiper/modules';
 
 
 // Reuse the same mock certificate data from DashboardPage


### PR DESCRIPTION
## Summary
- clean up unused Swiper imports
- drop `swiper` from dependencies
- update lock file

## Testing
- `npm install` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_e_68529376be9c8322ba87773676d05bad