### PR TITLE
Add ContactPage tests

### DIFF
--- a/src/components/auth/ProtectedRoute.test.js
+++ b/src/components/auth/ProtectedRoute.test.js
@@ -1,0 +1,57 @@
+import { render, screen } from '../../test-utils';
+import ProtectedRoute from './ProtectedRoute';
+import { Routes, Route, MemoryRouter } from 'react-router-dom';
+import React from 'react';
+
+const Secret = () => <div>secret</div>;
+
+const renderWithRoute = (ui, { user } = {}) => {
+  if (user) {
+    localStorage.setItem('user', JSON.stringify(user));
+  } else {
+    localStorage.removeItem('user');
+  }
+
+  return render(
+    <MemoryRouter initialEntries={["/dashboard"]}>
+      <Routes>
+        <Route path="/dashboard" element={ui} />
+        <Route path="/login" element={<div>login page</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('ProtectedRoute', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+  test('redirects unauthenticated users', () => {
+    renderWithRoute(
+      <ProtectedRoute>
+        <Secret />
+      </ProtectedRoute>
+    );
+    expect(screen.getByText(/login page/i)).toBeInTheDocument();
+  });
+
+  test('renders for authenticated admin', () => {
+    renderWithRoute(
+      <ProtectedRoute>
+        <Secret />
+      </ProtectedRoute>,
+      { user: { email: 'a@b.com', role: 'admin' } }
+    );
+    expect(screen.getByText(/secret/i)).toBeInTheDocument();
+  });
+
+  test('shows restricted message for guest', () => {
+    renderWithRoute(
+      <ProtectedRoute>
+        <Secret />
+      </ProtectedRoute>,
+      { user: { email: 'c@d.com', role: 'guest' } }
+    );
+    expect(screen.getByText(/restricted access/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/Layout.test.js
+++ b/src/components/layout/Layout.test.js
@@ -1,0 +1,22 @@
+import { render, screen } from '../../test-utils';
+import Header from './Header';
+import Footer from './Footer';
+
+describe('Header and Footer', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('navigation links and theme toggle appear', () => {
+    render(
+      <>
+        <Header />
+        <Footer />
+      </>
+    );
+
+    expect(screen.getAllByRole('link', { name: /home/i })[0]).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /switch to dark mode/i })).toBeInTheDocument();
+    expect(screen.getByText(/built with react/i)).toBeInTheDocument();
+  });
+});

--- a/src/context/AuthContext.test.js
+++ b/src/context/AuthContext.test.js
@@ -1,0 +1,35 @@
+import { renderHook, act } from '@testing-library/react';
+import { AuthProvider, useAuth } from './AuthContext';
+
+describe('AuthContext', () => {
+  const wrapper = ({ children }) => <AuthProvider>{children}</AuthProvider>;
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('login, 2FA and logout flow', () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    let response;
+    act(() => {
+      response = result.current.login('yugandharreddybana@outlook.com', 'admin123');
+    });
+
+    expect(response.requireVerification).toBe(true);
+    expect(result.current.verificationCode).toHaveLength(6);
+
+    const code = result.current.verificationCode;
+    act(() => {
+      response = result.current.login('yugandharreddybana@outlook.com', 'admin123', code);
+    });
+
+    expect(response.success).toBe(true);
+    expect(result.current.user.email).toBe('yugandharreddybana@outlook.com');
+
+    act(() => {
+      result.current.logout();
+    });
+    expect(result.current.user).toBeNull();
+  });
+});

--- a/src/context/ThemeContext.test.js
+++ b/src/context/ThemeContext.test.js
@@ -1,0 +1,29 @@
+import { renderHook, act } from '@testing-library/react';
+import { ThemeProvider, useTheme } from './ThemeContext';
+
+describe('ThemeContext', () => {
+  const wrapper = ({ children }) => <ThemeProvider>{children}</ThemeProvider>;
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('toggles theme and persists to localStorage', () => {
+    localStorage.setItem('theme', 'light');
+    const { result } = renderHook(() => useTheme(), { wrapper });
+    expect(result.current.theme).toBe('light');
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+
+    expect(result.current.theme).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  test('initializes from localStorage', () => {
+    localStorage.setItem('theme', 'dark');
+    const { result } = renderHook(() => useTheme(), { wrapper });
+    expect(result.current.theme).toBe('dark');
+  });
+});

--- a/src/pages/AppPages.test.js
+++ b/src/pages/AppPages.test.js
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent } from '../test-utils';
+import HomePage from './HomePage';
+import LoginPage from './LoginPage';
+
+describe('Pages', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('HomePage shows hero heading', () => {
+    render(<HomePage />);
+    expect(screen.getByRole('heading', { name: /yugandhar/i })).toBeInTheDocument();
+  });
+
+  test('LoginPage form validation', () => {
+    render(<LoginPage />);
+    const button = screen.getByRole('button', { name: /sign in/i });
+    fireEvent.click(button);
+    expect(screen.getByText(/email is required/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'test@example.com' } });
+    fireEvent.click(button);
+    expect(screen.getByText(/password is required/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/ContactPage.test.js
+++ b/src/pages/ContactPage.test.js
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent, act } from '../test-utils';
+import ContactPage from './ContactPage';
+
+describe('ContactPage', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('shows validation when required fields are empty', () => {
+    render(<ContactPage />);
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+    expect(
+      screen.getByText(/fill in all required fields/i)
+    ).toBeInTheDocument();
+  });
+
+  test('validates email format', () => {
+    render(<ContactPage />);
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: 'John' },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'invalid' },
+    });
+    fireEvent.change(screen.getByLabelText(/message/i), {
+      target: { value: 'Hi' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+    expect(
+      screen.getByText(/valid email address/i)
+    ).toBeInTheDocument();
+  });
+
+  test('submits successfully and clears form', () => {
+    jest.useFakeTimers();
+    render(<ContactPage />);
+
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: 'Jane' },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'jane@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/message/i), {
+      target: { value: 'Hello there' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    const success = screen.getByText(/your message has been sent/i);
+    expect(success).toBeInTheDocument();
+
+    expect(screen.getByLabelText(/name/i)).toHaveValue('');
+    expect(screen.getByLabelText(/email/i)).toHaveValue('');
+    expect(screen.getByLabelText(/subject/i)).toHaveValue('');
+    expect(screen.getByLabelText(/message/i)).toHaveValue('');
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(
+      screen.queryByText(/your message has been sent/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,16 @@
+import '@testing-library/jest-dom';
+
+// mock matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { AuthProvider } from './context/AuthContext';
+import { ThemeProvider } from './context/ThemeContext';
+
+const AllProviders = ({ children }) => (
+  <ThemeProvider>
+    <AuthProvider>
+      <BrowserRouter>
+        {children}
+      </BrowserRouter>
+    </AuthProvider>
+  </ThemeProvider>
+);
+
+const customRender = (ui, options) =>
+  render(ui, { wrapper: AllProviders, ...options });
+
+// re-export everything
+export * from '@testing-library/react';
+export { customRender as render };


### PR DESCRIPTION
## Summary
- add tests covering ContactPage form validation and submission

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685528e3db4c832297d1350633ef8bef