### PR TITLE
Add coverage script and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+coverage/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This project is a personal portfolio built with plain React using `react-scripts
 - `npm start` – start the development server
 - `npm run build` – build the production assets
 - `npm test` – run tests
+- `npm run coverage` – generate a coverage report
 
-Run `npm install` to install dev dependencies, then `npm test` to execute the Jest test suite.
+Run `npm install` to install dev dependencies. Use `npm test` for the interactive Jest runner or `npm run coverage` to generate a full coverage report. The HTML report can be viewed at `coverage/lcov-report/index.html` after the command completes.
 
 The app entry point is `src/index.js` and routing is handled with `react-router-dom`.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "coverage": "react-scripts test --coverage --watchAll=false",
     "eject": "react-scripts eject"
   },
   "browserslist": {


### PR DESCRIPTION
## Summary
- add `npm run coverage` script
- document coverage command in README
- ignore coverage output directory

## Testing
- `npm run coverage` *(fails: react-scripts not found)*