### PR TITLE
Add in-browser interview chatbot

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import EducationPage from './pages/EducationPage';
 import CertificationsPage from './pages/CertificationsPage';
 import ExperiencePage from './pages/ExperiencePage';
 import ContactPage from './pages/ContactPage';
+import ChatPage from './pages/ChatPage';
 import LoginPage from './pages/LoginPage';
 import DashboardPage from './pages/DashboardPage';
 import NotFoundPage from './pages/NotFoundPage';
@@ -35,6 +36,7 @@ function App() {
           <Route path="/certifications" element={<CertificationsPage />} />
           <Route path="/experience" element={<ExperiencePage />} />
           <Route path="/contact" element={<ContactPage />} />
+          <Route path="/chat" element={<ChatPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/resume-and-cover" element={<ResumeAndCoverPage />} />
 

--- a/src/components/chatbot/Chatbot.css
+++ b/src/components/chatbot/Chatbot.css
@@ -1,0 +1,78 @@
+.chatbot {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  max-width: 600px;
+  margin: 0 auto;
+  height: 500px;
+  background-color: var(--card);
+}
+
+.chat-window {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-4);
+}
+
+.message {
+  display: flex;
+  margin-bottom: var(--space-4);
+}
+
+.message.user {
+  justify-content: flex-start;
+}
+
+.message.bot {
+  justify-content: flex-end;
+}
+
+.avatar {
+  font-size: 1.5rem;
+}
+
+.message.user .avatar {
+  margin-right: var(--space-2);
+}
+
+.message.bot .avatar {
+  margin-left: var(--space-2);
+  order: 2;
+}
+
+.message-text {
+  max-width: 70%;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-lg);
+  background-color: var(--muted);
+}
+
+.message.user .message-text {
+  background-color: var(--secondary-100);
+}
+
+.message.bot .message-text {
+  background-color: var(--primary-100);
+}
+
+.chat-input {
+  display: flex;
+  border-top: 1px solid var(--border);
+}
+
+.chat-input input {
+  flex: 1;
+  border: none;
+  padding: var(--space-3);
+  background: transparent;
+  color: inherit;
+}
+
+.chat-input input:focus {
+  outline: none;
+}
+
+.chat-input button {
+  padding: var(--space-3) var(--space-6);
+}

--- a/src/components/chatbot/Chatbot.js
+++ b/src/components/chatbot/Chatbot.js
@@ -1,0 +1,64 @@
+import { useState, useEffect, useRef } from 'react';
+import qaData from './qaData';
+import './Chatbot.css';
+
+const fallback = "I'm not sure how to answer that. Try asking about my skills, education or experience.";
+
+const Chatbot = () => {
+  const [messages, setMessages] = useState([
+    { type: 'bot', text: 'Hi! Ask me about my background or skills.' }
+  ]);
+  const [input, setInput] = useState('');
+  const endRef = useRef(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const findAnswer = (q) => {
+    const lower = q.toLowerCase();
+    const match = qaData.find((qa) => lower.includes(qa.question.toLowerCase()));
+    return match ? match.answer : fallback;
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    const user = { type: 'user', text: input.trim() };
+    const bot = { type: 'bot', text: findAnswer(input.trim()) };
+    setMessages((msgs) => [...msgs, user, bot]);
+    setInput('');
+  };
+
+  return (
+    <div className="chatbot">
+      <div className="chat-window">
+        {messages.map((m, i) => (
+          <div key={i} className={`message ${m.type}`}>
+            <span
+              className="avatar"
+              role="img"
+              aria-label={m.type === 'user' ? 'interviewer' : 'developer'}
+            >
+              {m.type === 'user' ? '🧑\u200d💼' : '👨\u200d💻'}
+            </span>
+            <div className="message-text">{m.text}</div>
+          </div>
+        ))}
+        <div ref={endRef} />
+      </div>
+      <form className="chat-input" onSubmit={handleSubmit}>
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type your question"
+          aria-label="Type your question"
+        />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  );
+};
+
+export default Chatbot;

--- a/src/components/chatbot/Chatbot.test.js
+++ b/src/components/chatbot/Chatbot.test.js
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from '../../test-utils';
+import Chatbot from './Chatbot';
+
+describe('Chatbot', () => {
+  test('responds with matching answer', () => {
+    render(<Chatbot />);
+    fireEvent.change(screen.getByLabelText(/type your question/i), {
+      target: { value: 'Tell me about your skills' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+    expect(screen.getByText(/react, node\.js/i)).toBeInTheDocument();
+  });
+
+  test('falls back when no match', () => {
+    render(<Chatbot />);
+    fireEvent.change(screen.getByLabelText(/type your question/i), {
+      target: { value: 'What is your favorite color?' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+    expect(
+      screen.getByText(/i'm not sure how to answer that/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/chatbot/qaData.js
+++ b/src/components/chatbot/qaData.js
@@ -1,0 +1,22 @@
+export default [
+  {
+    question: 'skills',
+    answer: "I'm skilled in React, Node.js and data analysis with Python."
+  },
+  {
+    question: 'education',
+    answer: "I hold a Master's degree in Data Analytics from DCU."
+  },
+  {
+    question: 'experience',
+    answer: 'I have built telecom platforms, SaaS revamps and data science projects.'
+  },
+  {
+    question: 'location',
+    answer: "I'm based in Dublin, Ireland."
+  },
+  {
+    question: 'hobbies',
+    answer: 'Outside of coding I enjoy exploring data and cooking new recipes.'
+  }
+];

--- a/src/components/layout/Footer.js
+++ b/src/components/layout/Footer.js
@@ -27,6 +27,7 @@ const Footer = () => {
                 <li><Link to="/education">Education</Link></li>
                 <li><Link to="/certifications">Certifications</Link></li>
                 <li><Link to="/experience">Experience</Link></li>
+                <li><Link to="/chat">Chatbot</Link></li>
                 <li><Link to="/resume-and-cover">Cv & Cover Letter</Link></li>
                 <li><Link to="/contact">Contact</Link></li>
               </ul>

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -74,6 +74,11 @@ const Header = () => {
                 </NavLink>
               </li>
               <li className="nav-item">
+                <NavLink to="/chat" className={({ isActive }) => isActive ? 'active' : ''}>
+                  Chatbot
+                </NavLink>
+              </li>
+              <li className="nav-item">
                 <NavLink to="/resume-and-cover" className={({ isActive }) => isActive ? 'active' : ''}>
                   CV & Cover Letter
                 </NavLink>

--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -1,0 +1,8 @@
+.chat-page {
+  padding-top: 120px;
+}
+
+.chat-page h1 {
+  text-align: center;
+  margin-bottom: var(--space-6);
+}

--- a/src/pages/ChatPage.js
+++ b/src/pages/ChatPage.js
@@ -1,0 +1,13 @@
+import Chatbot from '../components/chatbot/Chatbot';
+import './ChatPage.css';
+
+const ChatPage = () => (
+  <div className="chat-page">
+    <div className="container">
+      <h1>Interview Chat</h1>
+      <Chatbot />
+    </div>
+  </div>
+);
+
+export default ChatPage;

--- a/src/pages/ContactPage.js
+++ b/src/pages/ContactPage.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import './ContactPage.css';
 
 const ContactPage = () => {
@@ -168,7 +169,7 @@ const ContactPage = () => {
                 <p>
                   Live chat is <strong>on the way</strong> – in the meantime feel free to email, phone, or connect on LinkedIn.
                 </p>
-                <button className="button outline">Coming Soon</button>
+                <Link to="/chat" className="button outline">Start Chat</Link>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add new `Chatbot` component for a frontend-only interview chat
- wire in `ChatPage` route and navigation links
- allow launching the bot from the Contact page
- create initial question/answer dataset
- include unit tests for the chatbot component
