### PR TITLE
Add education section to chatbot

### DIFF
--- a/src/components/chatbot/Chatbot.test.js
+++ b/src/components/chatbot/Chatbot.test.js
@@ -6,6 +6,7 @@ describe('Chatbot', () => {
     render(
       <>
         <section id="skills">Skilled in React and Node.js.</section>
+        <section id="education">Completed MSc in Data Analytics.</section>
         <Chatbot />
       </>
     );
@@ -14,6 +15,20 @@ describe('Chatbot', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /send/i }));
     expect(screen.getByText(/Skilled in React/i)).toBeInTheDocument();
+  });
+
+  test('responds to education question', () => {
+    render(
+      <>
+        <section id="education">Completed MSc in Data Analytics.</section>
+        <Chatbot />
+      </>
+    );
+    fireEvent.change(screen.getByLabelText(/type your question/i), {
+      target: { value: 'What education do you have?' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+    expect(screen.getByText(/Completed MSc/i)).toBeInTheDocument();
   });
 
   test('falls back when no match', () => {

--- a/src/components/chatbot/utils.js
+++ b/src/components/chatbot/utils.js
@@ -1,5 +1,5 @@
 export function extractKnowledgeBase() {
-  const ids = ['about', 'projects', 'experience', 'skills', 'contact'];
+  const ids = ['about', 'education', 'projects', 'experience', 'skills', 'contact'];
   const data = [];
   ids.forEach((id) => {
     const el = document.getElementById(id);

--- a/src/pages/AboutPage.js
+++ b/src/pages/AboutPage.js
@@ -11,7 +11,7 @@ const AboutPage = () => {
   }, []);
 
   return (
-    <div className="about-page">
+    <div id="about" className="about-page">
       <div className="container">
         {/* ───── header ───── */}
         <div className={`about-header fade-in-up ${animate ? 'run' : ''}`}>

--- a/src/pages/ContactPage.js
+++ b/src/pages/ContactPage.js
@@ -64,7 +64,7 @@ const ContactPage = () => {
 
   /* ─────────────────────────── render ─────────────────────────── */
   return (
-    <div className="contact-page">
+    <div id="contact" className="contact-page">
       <div className="container">
         {/* header */}
         <div className={`contact-header fade-in-up ${animate ? 'run' : ''}`}>

--- a/src/pages/EducationPage.js
+++ b/src/pages/EducationPage.js
@@ -10,7 +10,7 @@ const EducationPage = () => {
   }, []);
 
   return (
-    <div className="education-page">
+    <div id="education" className="education-page">
       <div className="container">
         {/* ───── header ───── */}
         <div className={`education-header fade-in-up ${animate ? 'run' : ''}`}>
@@ -138,6 +138,10 @@ const EducationPage = () => {
             </p>
           </div>
         </div>
+        <section id="skills" className="sr-only">
+          Python R SQL TensorFlow scikit-learn Tableau Power BI Java C++ HTML/CSS
+          JavaScript MySQL Software Design
+        </section>
       </div>
     </div>
   );

--- a/src/pages/ExperiencePage.js
+++ b/src/pages/ExperiencePage.js
@@ -92,7 +92,7 @@ const ExperiencePage = () => {
   }, []);
 
   return (
-    <div className="experience-page">
+    <div id="experience" className="experience-page">
       <div className="container">
         {/* ───────── header + tabs ───────── */}
         <div className={`experience-header fade-in-up ${animate ? 'run' : ''}`}>
@@ -153,7 +153,7 @@ const ExperiencePage = () => {
             ))}
           </div>
         ) : (
-          <div className="projects-grid">
+          <div id="projects" className="projects-grid">
             {projects.map((proj, i) => (
               <div
                 key={proj.id}


### PR DESCRIPTION
## Summary
- tag EducationPage wrapper with `id="education"`
- add hidden section with all skills
- expose page wrappers for the chatbot (`about`, `experience`, `projects`, `contact`)
- update chatbot utility to index the education section
- test chatbot answer for education questions
