### PR TITLE
Update README test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This project is a personal portfolio built with plain React using `react-scripts
 - `npm run build` – build the production assets
 - `npm test` – run tests and automatically generate a coverage report
 
-Run `npm install` to install dev dependencies. Use `npm test` for the interactive Jest runner. A full coverage report is generated automatically and can be viewed at `coverage/lcov-report/index.html` after the command completes.
+Run `npm install` before executing any other scripts, especially prior to running `npm test`, to ensure all dependencies are available. The interactive Jest runner can be started with `npm test`, and a full coverage report will be generated automatically. It can be viewed at `coverage/lcov-report/index.html` after the command completes.
+
+For CI environments a simple helper script is provided at `ci/setup.sh` which installs the dependencies before tests are executed.
 
 The app entry point is `src/index.js` and routing is handled with `react-router-dom`.

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Simple setup script for CI environments
+# Installs project dependencies before running tests
+npm install


### PR DESCRIPTION
## Summary
- clarify that `npm install` must run before `npm test`
- add a small helper script for CI setups

## Testing
- `npm install --silent` *(fails: internet access blocked)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b07349f5c8322b52813b78735bfa8