### PR TITLE
Prevent chatbot scrolling on /chat load

### DIFF
--- a/src/components/chatbot/Chatbot.js
+++ b/src/components/chatbot/Chatbot.js
@@ -17,7 +17,12 @@ const Chatbot = () => {
   }, []);
 
   useEffect(() => {
-    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const node = endRef.current;
+    if (!node) return;
+    const parent = node.parentElement;
+    if (parent && parent.scrollHeight > parent.clientHeight) {
+      node.scrollIntoView({ behavior: 'smooth' });
+    }
   }, [messages]);
 
   const handleSubmit = (e) => {

--- a/src/components/chatbot/Chatbot.test.js
+++ b/src/components/chatbot/Chatbot.test.js
@@ -41,4 +41,14 @@ describe('Chatbot', () => {
       screen.getByText(/please feel free to email me/i)
     ).toBeInTheDocument();
   });
+
+  test('does not scroll when chat is not overflowed', async () => {
+    const original = Element.prototype.scrollIntoView;
+    const spy = jest.fn();
+    Element.prototype.scrollIntoView = spy;
+    render(<Chatbot />);
+    await screen.findByText(/ask me anything/i);
+    expect(spy).not.toHaveBeenCalled();
+    Element.prototype.scrollIntoView = original;
+  });
 });


### PR DESCRIPTION
## Summary
- avoid scrolling the chatbot if no overflow
- ensure scrollIntoView isn't called when chat is short

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b13ae3b388322b69b19c7b36e01bf