### PR TITLE
Fix LeetCode progress circle dimensions

### DIFF
--- a/src/components/leetcode/ProgressCircle.js
+++ b/src/components/leetcode/ProgressCircle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import './ProgressCircle.css';
 
 const ProgressCircle = ({ label, value, total, color }) => {
-  const radius = 30;
+  const radius = 36;
   const stroke = 6;
   const normalizedRadius = radius - stroke;
   const circumference = 2 * Math.PI * normalizedRadius;
@@ -15,6 +15,7 @@ const ProgressCircle = ({ label, value, total, color }) => {
         className="progress-svg"
         height={radius * 2}
         width={radius * 2}
+        viewBox={`0 0 ${radius * 2} ${radius * 2}`}
       >
         <circle
           stroke="var(--muted)"
@@ -35,6 +36,7 @@ const ProgressCircle = ({ label, value, total, color }) => {
           r={normalizedRadius}
           cx={radius}
           cy={radius}
+          aria-label={`${label} progress`}
         />
       </svg>
       <div className="progress-text">{value}</div>

--- a/src/components/leetcode/ProgressCircle.test.js
+++ b/src/components/leetcode/ProgressCircle.test.js
@@ -1,0 +1,18 @@
+import { render } from '../../test-utils';
+import ProgressCircle from './ProgressCircle';
+import { screen } from '@testing-library/react';
+
+describe('ProgressCircle', () => {
+  test('renders with correct stroke offset', () => {
+    render(
+      <ProgressCircle label="Easy" value={25} total={50} color="red" />
+    );
+
+    const circle = screen.getByLabelText('Easy progress');
+    const offset = parseFloat(circle.getAttribute('stroke-dashoffset'));
+    const expectedRadius = 30; // radius 36 - stroke 6
+    const circumference = 2 * Math.PI * expectedRadius;
+    const expectedOffset = circumference - 0.5 * circumference;
+    expect(offset).toBeCloseTo(expectedOffset);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the progress circle SVG has matching width/height
- add `viewBox` attribute and ARIA label
- create regression test for stroke offset

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a35a3c50832282138e03f3ac2d61