### PR TITLE
Remove unused difficulty percentage calculations

### DIFF
--- a/src/pages/LeetCodePage.js
+++ b/src/pages/LeetCodePage.js
@@ -125,9 +125,6 @@ const LeetCodePage = () => {
   }, [problems]);
 
   const totalSolved = problems.length;
-  const easyPct = totalSolved ? (difficultyCounts.Easy / totalSolved) * 100 : 0;
-  const medPct = totalSolved ? (difficultyCounts.Medium / totalSolved) * 100 : 0;
-  const hardPct = totalSolved ? (difficultyCounts.Hard / totalSolved) * 100 : 0;
 
   const filteredProblems = useMemo(() => {
     const now = new Date();


### PR DESCRIPTION
## Summary
- remove leftover `easyPct`, `medPct` and `hardPct` calculations in LeetCode page
- clean up code after removing the unused values