### PR TITLE
Add pagination controls to LeetCode table

### DIFF
--- a/src/pages/LeetCodePage.css
+++ b/src/pages/LeetCodePage.css
@@ -267,6 +267,17 @@
   padding: var(--space-1) var(--space-2);
 }
 
+.pagination-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+}
+
+.pagination-controls select {
+  padding: var(--space-1) var(--space-2);
+}
+
 .no-results {
   grid-column: 1 / -1;
   text-align: center;

--- a/src/pages/LeetCodePage.js
+++ b/src/pages/LeetCodePage.js
@@ -112,6 +112,9 @@ const LeetCodePage = () => {
 
   const [dateRange, setDateRange] = useState('all');
 
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(5);
+
   const difficultyCounts = useMemo(() => {
     const counts = { Easy: 0, Medium: 0, Hard: 0 };
     problems.forEach((p) => {
@@ -136,6 +139,17 @@ const LeetCodePage = () => {
       return true;
     });
   }, [problems, difficultyFilter, dateRange]);
+
+  const paginatedProblems = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return filteredProblems.slice(start, start + pageSize);
+  }, [filteredProblems, currentPage, pageSize]);
+
+  const totalPages = Math.ceil(filteredProblems.length / pageSize) || 1;
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [difficultyFilter, dateRange, pageSize]);
 
   useEffect(() => {
     localStorage.setItem('leetcodeProblems', JSON.stringify(problems));
@@ -209,6 +223,18 @@ const LeetCodePage = () => {
     setDateRange(e.target.value);
   };
 
+  const handlePageSizeChange = (e) => {
+    setPageSize(Number(e.target.value));
+  };
+
+  const handlePrevPage = () => {
+    setCurrentPage((p) => Math.max(1, p - 1));
+  };
+
+  const handleNextPage = () => {
+    setCurrentPage((p) => Math.min(totalPages, p + 1));
+  };
+
   return (
     <div className="leetcode-page">
       <div className="container">
@@ -272,9 +298,9 @@ const LeetCodePage = () => {
                   </tr>
                 </thead>
                 <tbody>
-                  {filteredProblems.map((p, idx) => (
+                  {paginatedProblems.map((p, idx) => (
                     <tr key={p.id}>
-                      <td>{idx + 1}</td>
+                      <td>{(currentPage - 1) * pageSize + idx + 1}</td>
                       <td>
                         <a href={p.link} target="_blank" rel="noopener noreferrer">
                           {p.title}
@@ -301,6 +327,32 @@ const LeetCodePage = () => {
                   ))}
                 </tbody>
               </table>
+              <div className="pagination-controls">
+                <button
+                  className="button outline"
+                  onClick={handlePrevPage}
+                  disabled={currentPage === 1}
+                >
+                  Prev
+                </button>
+                <span>{`Page ${currentPage} of ${totalPages}`}</span>
+                <button
+                  className="button outline"
+                  onClick={handleNextPage}
+                  disabled={currentPage === totalPages}
+                >
+                  Next
+                </button>
+                <select
+                  aria-label="page size"
+                  value={pageSize}
+                  onChange={handlePageSizeChange}
+                >
+                  <option value={5}>5</option>
+                  <option value={10}>10</option>
+                  <option value={20}>20</option>
+                </select>
+              </div>
             </div>
 
             {filteredProblems.length === 0 && (

--- a/src/pages/LeetCodePage.test.js
+++ b/src/pages/LeetCodePage.test.js
@@ -39,4 +39,30 @@ describe('LeetCodePage', () => {
 
     expect(screen.getByText(/total solved/i)).toHaveTextContent('4');
   });
+
+  test('pagination controls navigate through pages', () => {
+    const manyProblems = Array.from({ length: 7 }, (_, i) => ({
+      id: String(i + 1),
+      title: `Problem ${i + 1}`,
+      difficulty: 'Easy',
+      link: '#',
+      dateSolved: '2024-01-01T00:00:00.000Z'
+    }));
+    localStorage.setItem('leetcodeProblems', JSON.stringify(manyProblems));
+    render(<LeetCodePage />);
+
+    // first page shows first five problems
+    expect(screen.getByText('Problem 5')).toBeInTheDocument();
+    expect(screen.queryByText('Problem 6')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(screen.getByText('Problem 6')).toBeInTheDocument();
+    expect(screen.getByText('Problem 7')).toBeInTheDocument();
+    expect(screen.queryByText('Problem 1')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /prev/i }));
+
+    expect(screen.getByText('Problem 1')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- introduce `currentPage` and `pageSize` state in `LeetCodePage`
- slice `filteredProblems` into new `paginatedProblems`
- add prev/next buttons and page size dropdown
- style pagination controls
- cover pagination behavior in tests

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a92719688322ba9d4f4c5a6c263a