### PR TITLE
Ensure npm install precedes tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is a personal portfolio built with plain React using `react-scripts
 - `npm run build` – build the production assets
 - `npm test` – run tests and automatically generate a coverage report
 
-Run `npm install` before executing any other scripts so that `react-scripts` and the other dev dependencies are available.
+Run `npm install` before executing any other scripts, especially before running `npm test`, so that `react-scripts` and the other dev dependencies are available.
 
 ## Running Tests
 
@@ -20,6 +20,8 @@ npm test
 ```
 
 This installs all dependencies and then starts the Jest runner, generating a coverage report that can be viewed at `coverage/lcov-report/index.html`.
+
+`npm test` will automatically run `npm install` first thanks to the `pretest` script defined in `package.json`.
 
 For CI environments a helper script is provided at `ci/setup.sh` which performs the `npm install` step before tests are executed.
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build": "react-scripts build",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
+    "pretest": "npm install",
     "test": "react-scripts test --coverage --watchAll=false",
     "coverage": "npm test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
## Summary
- mention that `npm install` must run before `npm test`
- automatically run `npm install` via `pretest` script