### PR TITLE
Fix sticky close button in LeetCode modals

### DIFF
--- a/src/pages/LeetCodePage.css
+++ b/src/pages/LeetCodePage.css
@@ -147,13 +147,15 @@
   max-height: 90vh;
   overflow-y: auto;
   position: relative;
+  padding-top: var(--space-12);
   animation: scaleIn var(--transition-normal);
 }
 
 .close-button {
-  position: absolute;
+  position: sticky;
   top: var(--space-4);
-  right: var(--space-4);
+  margin-left: auto;
+  margin-right: var(--space-4);
   background-color: var(--muted);
   border: none;
   width: 32px;


### PR DESCRIPTION
## Summary
- ensure LeetCode modals keep the close button visible while scrolling

## Testing
- `npm test` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6867c03e652883229671aeff001eee0c