### PR TITLE
Switch to API-based data loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ The app entry point is `src/index.js` and routing is handled with `react-router-
 
 ## LeetCode Page
 
-The `/leetcode` route lets you track algorithm problems you've solved. Each entry
-is stored in `localStorage` so that your list persists between sessions. Clicking
-a problem opens a modal where you can view the solution in either JavaScript or
-Python using dedicated tabs.
+The `/leetcode` route lets you track algorithm problems you've solved. Data is
+loaded from the backend via the new API service and displayed in a paginated
+table. Clicking a problem opens a modal where you can view the solution in
+either JavaScript or Python using dedicated tabs.
 
 
 ## License

--- a/src/pages/CertificationsPage.js
+++ b/src/pages/CertificationsPage.js
@@ -1,25 +1,24 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import './CertificationsPage.css';
 
 import defaultCertificates from '../data/certificates';
+import { fetchCertificates } from '../services/api';
 
 
 const CertificationsPage = () => {
-  const [certificates, setCertificates] = useState(() => {
-    try {
-      const saved = localStorage.getItem("certificates");
-      return saved ? JSON.parse(saved) : defaultCertificates;
-    } catch (e) {
-      console.error("Failed to parse certificates", e);
-      return defaultCertificates;
-    }
-  });
+  const [certificates, setCertificates] = useState([]);
   const [selectedCertificate, setSelectedCertificate] = useState(null);
   const [filter, setFilter] = useState('All');
   const { user } = useAuth();
-  
+
   const categories = ['All', 'Development', 'Data', 'Cloud', 'Design', 'Academic'];
+
+  useEffect(() => {
+    fetchCertificates()
+      .then(setCertificates)
+      .catch(() => setCertificates(defaultCertificates));
+  }, []);
   
   const filteredCertificates = filter === 'All'
     ? certificates

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -3,18 +3,11 @@ import { useAuth } from '../context/AuthContext';
 import './DashboardPage.css';
 
 import defaultCertificates from '../data/certificates';
+import { fetchCertificates } from '../services/api';
 
 const DashboardPage = () => {
   const { user } = useAuth();
-  const [certificates, setCertificates] = useState(() => {
-    try {
-      const saved = localStorage.getItem('certificates');
-      return saved ? JSON.parse(saved) : defaultCertificates;
-    } catch (e) {
-      console.error('Failed to parse certificates', e);
-      return defaultCertificates;
-    }
-  });
+  const [certificates, setCertificates] = useState([]);
   const [newCertificate, setNewCertificate] = useState({
     title: '',
     issuer: '',
@@ -31,9 +24,12 @@ const DashboardPage = () => {
   const [confirmDelete, setConfirmDelete] = useState(null);
 
   const categories = ['Development', 'Data', 'Cloud', 'Design', 'Other'];
+
   useEffect(() => {
-    localStorage.setItem("certificates", JSON.stringify(certificates));
-  }, [certificates]);
+    fetchCertificates()
+      .then(setCertificates)
+      .catch(() => setCertificates(defaultCertificates));
+  }, []);
   
   const currentDate = new Date();
   const hours = currentDate.getHours();

--- a/src/pages/LeetCodePage.js
+++ b/src/pages/LeetCodePage.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import './LeetCodePage.css';
 import defaultProblems from '../data/leetcodeProblems';
 import ProgressCircle from '../components/leetcode/ProgressCircle';
+import { fetchLeetcodeProblems } from '../services/api';
 
 
 
@@ -83,15 +84,7 @@ const ProblemModal = ({ problem, onClose, onEdit }) => {
 };
 
 const LeetCodePage = () => {
-  const [problems, setProblems] = useState(() => {
-    try {
-      const saved = localStorage.getItem('leetcodeProblems');
-      return saved ? JSON.parse(saved) : defaultProblems;
-    } catch (e) {
-      console.error('Failed to parse problems', e);
-      return defaultProblems;
-    }
-  });
+  const [problems, setProblems] = useState([]);
 
   const initialForm = {
     lcId: '',
@@ -117,6 +110,12 @@ const LeetCodePage = () => {
 
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(5);
+
+  useEffect(() => {
+    fetchLeetcodeProblems()
+      .then(setProblems)
+      .catch(() => setProblems(defaultProblems));
+  }, []);
 
   const difficultyCounts = useMemo(() => {
     const counts = { Easy: 0, Medium: 0, Hard: 0 };
@@ -145,10 +144,6 @@ const LeetCodePage = () => {
   useEffect(() => {
     setCurrentPage(1);
   }, [difficultyFilter, pageSize]);
-
-  useEffect(() => {
-    localStorage.setItem('leetcodeProblems', JSON.stringify(problems));
-  }, [problems]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;

--- a/src/pages/LeetCodePage.test.js
+++ b/src/pages/LeetCodePage.test.js
@@ -1,13 +1,21 @@
 import { render, screen, fireEvent } from '../test-utils';
 import LeetCodePage from './LeetCodePage';
+import defaultProblems from '../data/leetcodeProblems';
 
 describe('LeetCodePage', () => {
-  afterEach(() => {
-    localStorage.clear();
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(defaultProblems) })
+    );
   });
 
-  test('opens form and adds a new problem', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('opens form and adds a new problem', async () => {
     render(<LeetCodePage />);
+    await screen.findByText('Two Sum');
     fireEvent.click(screen.getByRole('button', { name: /add new problem/i }));
     fireEvent.change(screen.getByLabelText(/lc id/i), { target: { value: '99' } });
     fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'Sample' } });
@@ -16,8 +24,9 @@ describe('LeetCodePage', () => {
     expect(screen.getByText('Sample')).toBeInTheDocument();
   });
 
-  test('editing pre-fills the form', () => {
+  test('editing pre-fills the form', async () => {
     render(<LeetCodePage />);
+    await screen.findByText('Two Sum');
     // open add form and create item
     fireEvent.click(screen.getByRole('button', { name: /add new problem/i }));
     fireEvent.change(screen.getByLabelText(/lc id/i), { target: { value: '1' } });
@@ -30,8 +39,9 @@ describe('LeetCodePage', () => {
     expect(screen.getByDisplayValue('Old')).toBeInTheDocument();
   });
 
-  test('updates total solved count when new problem is added', () => {
+  test('updates total solved count when new problem is added', async () => {
     render(<LeetCodePage />);
+    await screen.findByText('Two Sum');
     expect(screen.getByText(/total solved/i)).toHaveTextContent('3');
 
     fireEvent.click(screen.getByRole('button', { name: /add new problem/i }));
@@ -43,7 +53,7 @@ describe('LeetCodePage', () => {
     expect(screen.getByText(/total solved/i)).toHaveTextContent('4');
   });
 
-  test('pagination controls navigate through pages', () => {
+  test('pagination controls navigate through pages', async () => {
     const manyProblems = Array.from({ length: 7 }, (_, i) => ({
       id: String(i + 1),
       lcId: String(i + 1),
@@ -52,8 +62,12 @@ describe('LeetCodePage', () => {
       link: '#',
       dateSolved: '2024-01-01T00:00:00.000Z'
     }));
-    localStorage.setItem('leetcodeProblems', JSON.stringify(manyProblems));
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(manyProblems)
+    });
     render(<LeetCodePage />);
+    await screen.findByText('Problem 5');
 
     // first page shows first five problems
     expect(screen.getByText('Problem 5')).toBeInTheDocument();
@@ -70,8 +84,9 @@ describe('LeetCodePage', () => {
     expect(screen.getByText('Problem 1')).toBeInTheDocument();
   });
 
-  test('deletes a problem after confirmation', () => {
+  test('deletes a problem after confirmation', async () => {
     render(<LeetCodePage />);
+    await screen.findByText('Two Sum');
     fireEvent.click(screen.getByLabelText(/delete two sum/i));
     fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
     expect(screen.queryByText('Two Sum')).not.toBeInTheDocument();

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,29 @@
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '';
+
+export async function login(email, password, code) {
+  const response = await fetch(`${API_BASE_URL}/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password, code })
+  });
+  if (!response.ok) {
+    throw new Error('Failed to login');
+  }
+  return response.json();
+}
+
+export async function fetchCertificates() {
+  const response = await fetch(`${API_BASE_URL}/certificates`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch certificates');
+  }
+  return response.json();
+}
+
+export async function fetchLeetcodeProblems() {
+  const response = await fetch(`${API_BASE_URL}/leetcode`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch problems');
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- add an `api.js` service with `login`, `fetchCertificates` and `fetchLeetcodeProblems`
- load certificates and problems via API calls
- update LeetCode tests to mock fetch
- note API fetching in README

## Testing
- `npm test` *(fails: npm install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686aae95167883229b1044f67559026e