### PR TITLE
Add basic Express backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "framer-motion": "^10.18.0",
+    "express": "^4.19.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^4.12.0",
@@ -26,7 +27,8 @@
     "pretest": "npm install",
     "test": "react-scripts test --coverage --watchAll=false",
     "coverage": "npm test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "server": "node server/index.js"
   },
   "browserslist": {
     "production": [

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 5000;
+
+app.use(express.json());
+
+// In-memory data stores
+const certificates = [];
+const experiences = [];
+const projects = [];
+const leetcode = [];
+
+function findItem(arr, id) {
+  return arr.findIndex(item => item.id === id);
+}
+
+// Generic CRUD handlers
+function setupCrudRoutes(path, store) {
+  app.get(path, (req, res) => {
+    res.json(store);
+  });
+
+  app.post(path, (req, res) => {
+    const item = { id: Date.now().toString(), ...req.body };
+    store.push(item);
+    res.status(201).json(item);
+  });
+
+  app.put(`${path}/:id`, (req, res) => {
+    const idx = findItem(store, req.params.id);
+    if (idx === -1) return res.sendStatus(404);
+    store[idx] = { ...store[idx], ...req.body };
+    res.json(store[idx]);
+  });
+
+  app.delete(`${path}/:id`, (req, res) => {
+    const idx = findItem(store, req.params.id);
+    if (idx === -1) return res.sendStatus(404);
+    const [deleted] = store.splice(idx, 1);
+    res.json(deleted);
+  });
+}
+
+setupCrudRoutes('/certificates', certificates);
+setupCrudRoutes('/experiences', experiences);
+setupCrudRoutes('/projects', projects);
+setupCrudRoutes('/leetcode', leetcode);
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '';
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:5000';
 
 export async function login(email, password, code) {
   const response = await fetch(`${API_BASE_URL}/login`, {


### PR DESCRIPTION
## Summary
- add simple Express server with CRUD routes
- wire frontend API service to localhost backend
- include server start script and express dependency

## Testing
- `npm test` *(fails: unable to download npm packages)*

------
https://chatgpt.com/codex/tasks/task_e_686ab861c8c4832299ccd35ef79b406d