### PR TITLE
Implement dashboard providers and management

### DIFF
--- a/src/components/dashboard/DashboardExperiences.js
+++ b/src/components/dashboard/DashboardExperiences.js
@@ -1,7 +1,234 @@
+import { useState } from 'react';
+import { useExperiences } from '../../context/ExperiencesContext';
+import '../../pages/DashboardPage.css';
+
+const initialForm = {
+  position: '',
+  company: '',
+  period: '',
+  description: '',
+};
+
 const DashboardExperiences = () => {
+  const {
+    experiences,
+    loading,
+    error,
+    addExperience,
+    updateExperienceById,
+    deleteExperienceById,
+  } = useExperiences();
+
+  const [isAdding, setIsAdding] = useState(false);
+  const [formData, setFormData] = useState(initialForm);
+  const [editingId, setEditingId] = useState(null);
+  const [notification, setNotification] = useState(null);
+  const [confirmDelete, setConfirmDelete] = useState(null);
+
+  const showNotification = (message, type = 'success') => {
+    setNotification({ message, type });
+    setTimeout(() => setNotification(null), 3000);
+  };
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const exp = {
+      position: formData.position,
+      company: formData.company,
+      period: formData.period,
+      description: formData.description,
+    };
+
+    if (editingId) {
+      const { success } = await updateExperienceById(editingId, exp);
+      if (success) {
+        showNotification('Experience updated successfully');
+      } else {
+        showNotification('Failed to update experience', 'error');
+        return;
+      }
+    } else {
+      const { success } = await addExperience(exp);
+      if (success) {
+        showNotification('Experience added successfully');
+      } else {
+        showNotification('Failed to add experience', 'error');
+        return;
+      }
+    }
+
+    setFormData(initialForm);
+    setEditingId(null);
+    setIsAdding(false);
+  };
+
+  const handleEdit = (id) => {
+    const exp = experiences.find((e) => e.id === id);
+    if (!exp) return;
+    setEditingId(id);
+    setFormData({
+      position: exp.position || '',
+      company: exp.company || '',
+      period: exp.period || '',
+      description: exp.description || '',
+    });
+    setIsAdding(true);
+  };
+
+  const handleConfirmDelete = async () => {
+    const { success } = await deleteExperienceById(confirmDelete);
+    if (success) {
+      showNotification('Experience deleted successfully');
+    } else {
+      showNotification('Failed to delete experience', 'error');
+    }
+    setConfirmDelete(null);
+  };
+
+  if (loading) {
+    return <div className="loading">Loading...</div>;
+  }
+
+  if (error) {
+    return <div className="error">{error}</div>;
+  }
+
   return (
-    <div className="dashboard-placeholder">
-      <h2>Experience management coming soon.</h2>
+    <div className="problems-section">
+      <div className="dashboard-header">
+        <h2>Experience</h2>
+        <button
+          className="button"
+          onClick={() => {
+            setIsAdding(true);
+            setEditingId(null);
+            setFormData(initialForm);
+          }}
+        >
+          Add Experience
+        </button>
+      </div>
+
+      {notification && (
+        <div className={`notification ${notification.type}`}>{notification.message}</div>
+      )}
+
+      {confirmDelete && (
+        <div className="confirm-dialog">
+          <div className="confirm-dialog-content">
+            <h3>Delete this experience?</h3>
+            <p>This action can't be undone.</p>
+            <div className="confirm-dialog-actions">
+              <button onClick={() => setConfirmDelete(null)} className="button outline">Cancel</button>
+              <button onClick={handleConfirmDelete} className="button accent">Delete</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {isAdding ? (
+        <div className="certificate-form-container">
+          <h2>{editingId ? 'Edit Experience' : 'Add New Experience'}</h2>
+          <form className="certificate-form" onSubmit={handleSubmit}>
+            <div className="form-group">
+              <label htmlFor="position">Position*</label>
+              <input
+                id="position"
+                name="position"
+                type="text"
+                value={formData.position}
+                onChange={handleChange}
+                required
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="company">Company*</label>
+              <input
+                id="company"
+                name="company"
+                type="text"
+                value={formData.company}
+                onChange={handleChange}
+                required
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="period">Period</label>
+              <input
+                id="period"
+                name="period"
+                type="text"
+                value={formData.period}
+                onChange={handleChange}
+              />
+            </div>
+            <div className="form-group" style={{ gridColumn: 'span 2' }}>
+              <label htmlFor="description">Description</label>
+              <textarea
+                id="description"
+                name="description"
+                rows="3"
+                value={formData.description}
+                onChange={handleChange}
+              />
+            </div>
+            <div className="form-actions">
+              <button type="button" className="button outline" onClick={() => { setIsAdding(false); setEditingId(null); }}>
+                Cancel
+              </button>
+              <button type="submit" className="button">
+                {editingId ? 'Save Changes' : 'Add Experience'}
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : (
+        <div className="certificates-container">
+          {experiences.length === 0 ? (
+            <div className="empty-state">
+              <h3>No experiences added yet.</h3>
+            </div>
+          ) : (
+            <div className="certificates-grid">
+              {experiences.map((exp) => (
+                <div className="certificate-card" key={exp.id}>
+                  <div className="certificate-details">
+                    <h3>{exp.position}</h3>
+                    <p className="certificate-issuer">{exp.company}</p>
+                    {exp.period && (
+                      <p className="certificate-date">{exp.period}</p>
+                    )}
+                    {exp.description && (
+                      <p className="certificate-takeaway">{exp.description}</p>
+                    )}
+                  </div>
+                  <div className="certificate-actions">
+                    <button
+                      className="icon-button edit-button"
+                      onClick={() => handleEdit(exp.id)}
+                      aria-label="Edit experience"
+                    >
+                      ✏️
+                    </button>
+                    <button
+                      className="icon-button delete-button"
+                      onClick={() => setConfirmDelete(exp.id)}
+                      aria-label="Delete experience"
+                    >
+                      🗑️
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/dashboard/DashboardProjects.js
+++ b/src/components/dashboard/DashboardProjects.js
@@ -1,7 +1,237 @@
+import { useState } from 'react';
+import { useProjects } from '../../context/ProjectsContext';
+import '../../pages/DashboardPage.css';
+
+const initialForm = {
+  title: '',
+  description: '',
+  imageUrl: '',
+  technologies: '',
+};
+
 const DashboardProjects = () => {
+  const {
+    projects,
+    loading,
+    error,
+    addProject,
+    updateProjectById,
+    deleteProjectById,
+  } = useProjects();
+
+  const [isAdding, setIsAdding] = useState(false);
+  const [formData, setFormData] = useState(initialForm);
+  const [editingId, setEditingId] = useState(null);
+  const [notification, setNotification] = useState(null);
+  const [confirmDelete, setConfirmDelete] = useState(null);
+
+  const showNotification = (message, type = 'success') => {
+    setNotification({ message, type });
+    setTimeout(() => setNotification(null), 3000);
+  };
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const proj = {
+      title: formData.title,
+      description: formData.description,
+      imageUrl: formData.imageUrl,
+      technologies: formData.technologies,
+    };
+
+    if (editingId) {
+      const { success } = await updateProjectById(editingId, proj);
+      if (success) {
+        showNotification('Project updated successfully');
+      } else {
+        showNotification('Failed to update project', 'error');
+        return;
+      }
+    } else {
+      const { success } = await addProject(proj);
+      if (success) {
+        showNotification('Project added successfully');
+      } else {
+        showNotification('Failed to add project', 'error');
+        return;
+      }
+    }
+
+    setFormData(initialForm);
+    setEditingId(null);
+    setIsAdding(false);
+  };
+
+  const handleEdit = (id) => {
+    const proj = projects.find((p) => p.id === id);
+    if (!proj) return;
+    setEditingId(id);
+    setFormData({
+      title: proj.title || '',
+      description: proj.description || '',
+      imageUrl: proj.imageUrl || '',
+      technologies: proj.technologies || '',
+    });
+    setIsAdding(true);
+  };
+
+  const handleConfirmDelete = async () => {
+    const { success } = await deleteProjectById(confirmDelete);
+    if (success) {
+      showNotification('Project deleted successfully');
+    } else {
+      showNotification('Failed to delete project', 'error');
+    }
+    setConfirmDelete(null);
+  };
+
+  if (loading) {
+    return <div className="loading">Loading...</div>;
+  }
+
+  if (error) {
+    return <div className="error">{error}</div>;
+  }
+
   return (
-    <div className="dashboard-placeholder">
-      <h2>Project management coming soon.</h2>
+    <div className="problems-section">
+      <div className="dashboard-header">
+        <h2>Projects</h2>
+        <button
+          className="button"
+          onClick={() => {
+            setIsAdding(true);
+            setEditingId(null);
+            setFormData(initialForm);
+          }}
+        >
+          Add Project
+        </button>
+      </div>
+
+      {notification && (
+        <div className={`notification ${notification.type}`}>{notification.message}</div>
+      )}
+
+      {confirmDelete && (
+        <div className="confirm-dialog">
+          <div className="confirm-dialog-content">
+            <h3>Delete this project?</h3>
+            <p>This action can't be undone.</p>
+            <div className="confirm-dialog-actions">
+              <button onClick={() => setConfirmDelete(null)} className="button outline">Cancel</button>
+              <button onClick={handleConfirmDelete} className="button accent">Delete</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {isAdding ? (
+        <div className="certificate-form-container">
+          <h2>{editingId ? 'Edit Project' : 'Add New Project'}</h2>
+          <form className="certificate-form" onSubmit={handleSubmit}>
+            <div className="form-group">
+              <label htmlFor="title">Title*</label>
+              <input
+                id="title"
+                name="title"
+                type="text"
+                value={formData.title}
+                onChange={handleChange}
+                required
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="imageUrl">Image URL</label>
+              <input
+                id="imageUrl"
+                name="imageUrl"
+                type="text"
+                value={formData.imageUrl}
+                onChange={handleChange}
+              />
+            </div>
+            <div className="form-group" style={{ gridColumn: 'span 2' }}>
+              <label htmlFor="description">Description</label>
+              <textarea
+                id="description"
+                name="description"
+                rows="3"
+                value={formData.description}
+                onChange={handleChange}
+              />
+            </div>
+            <div className="form-group" style={{ gridColumn: 'span 2' }}>
+              <label htmlFor="technologies">Technologies</label>
+              <input
+                id="technologies"
+                name="technologies"
+                type="text"
+                value={formData.technologies}
+                onChange={handleChange}
+              />
+            </div>
+            <div className="form-actions">
+              <button type="button" className="button outline" onClick={() => { setIsAdding(false); setEditingId(null); }}>
+                Cancel
+              </button>
+              <button type="submit" className="button">
+                {editingId ? 'Save Changes' : 'Add Project'}
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : (
+        <div className="certificates-container">
+          {projects.length === 0 ? (
+            <div className="empty-state">
+              <h3>No projects added yet.</h3>
+            </div>
+          ) : (
+            <div className="certificates-grid">
+              {projects.map((proj) => (
+                <div className="certificate-card" key={proj.id}>
+                  {proj.imageUrl && (
+                    <div className="certificate-image">
+                      <img src={proj.imageUrl} alt={proj.title} />
+                    </div>
+                  )}
+                  <div className="certificate-details">
+                    <h3>{proj.title}</h3>
+                    {proj.description && (
+                      <p className="certificate-takeaway">{proj.description}</p>
+                    )}
+                    {proj.technologies && (
+                      <p className="certificate-issuer">{proj.technologies}</p>
+                    )}
+                  </div>
+                  <div className="certificate-actions">
+                    <button
+                      className="icon-button edit-button"
+                      onClick={() => handleEdit(proj.id)}
+                      aria-label="Edit project"
+                    >
+                      ✏️
+                    </button>
+                    <button
+                      className="icon-button delete-button"
+                      onClick={() => setConfirmDelete(proj.id)}
+                      aria-label="Delete project"
+                    >
+                      🗑️
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -1,5 +1,8 @@
 import { useState } from 'react';
 import './DashboardPage.css';
+import { CertificatesProvider } from '../context/CertificatesContext';
+import { ExperiencesProvider } from '../context/ExperiencesContext';
+import { ProjectsProvider } from '../context/ProjectsContext';
 import { ProblemsProvider } from '../context/ProblemsContext';
 import DashboardCertificates from '../components/dashboard/DashboardCertificates';
 import DashboardExperiences from '../components/dashboard/DashboardExperiences';
@@ -10,43 +13,49 @@ const DashboardPage = () => {
   const [activeTab, setActiveTab] = useState('certificates');
 
   return (
-    <ProblemsProvider>
-      <div className="dashboard-page">
-        <div className="container">
-          <div className="tabs">
-            <button
-              className={`tab ${activeTab === 'certificates' ? 'active' : ''}`}
-              onClick={() => setActiveTab('certificates')}
-            >
-              Certificates
-            </button>
-            <button
-              className={`tab ${activeTab === 'experience' ? 'active' : ''}`}
-              onClick={() => setActiveTab('experience')}
-            >
-              Experience
-            </button>
-            <button
-              className={`tab ${activeTab === 'projects' ? 'active' : ''}`}
-              onClick={() => setActiveTab('projects')}
-            >
-              Projects
-            </button>
-            <button
-              className={`tab ${activeTab === 'leetcode' ? 'active' : ''}`}
-              onClick={() => setActiveTab('leetcode')}
-            >
-              LeetCode
-            </button>
-          </div>
+    <CertificatesProvider>
+      <ExperiencesProvider>
+        <ProjectsProvider>
+          <ProblemsProvider>
+            <div className="dashboard-page">
+              <div className="container">
+                <div className="tabs">
+                  <button
+                    className={`tab ${activeTab === 'certificates' ? 'active' : ''}`}
+                    onClick={() => setActiveTab('certificates')}
+                  >
+                    Certificates
+                  </button>
+                  <button
+                    className={`tab ${activeTab === 'experience' ? 'active' : ''}`}
+                    onClick={() => setActiveTab('experience')}
+                  >
+                    Experience
+                  </button>
+                  <button
+                    className={`tab ${activeTab === 'projects' ? 'active' : ''}`}
+                    onClick={() => setActiveTab('projects')}
+                  >
+                    Projects
+                  </button>
+                  <button
+                    className={`tab ${activeTab === 'leetcode' ? 'active' : ''}`}
+                    onClick={() => setActiveTab('leetcode')}
+                  >
+                    LeetCode
+                  </button>
+                </div>
 
-          {activeTab === 'certificates' && <DashboardCertificates />}
-          {activeTab === 'experience' && <DashboardExperiences />}
-          {activeTab === 'projects' && <DashboardProjects />}
-          {activeTab === 'leetcode' && <ProblemsSection />}
-        </div>
-      </div>
-    </ProblemsProvider>
+                {activeTab === 'certificates' && <DashboardCertificates />}
+                {activeTab === 'experience' && <DashboardExperiences />}
+                {activeTab === 'projects' && <DashboardProjects />}
+                {activeTab === 'leetcode' && <ProblemsSection />}
+              </div>
+            </div>
+          </ProblemsProvider>
+        </ProjectsProvider>
+      </ExperiencesProvider>
+    </CertificatesProvider>
   );
 };
 


### PR DESCRIPTION
## Summary
- wrap `DashboardPage` with CertificatesProvider, ExperiencesProvider, ProjectsProvider and ProblemsProvider
- build full dashboard sections for experiences and projects using context API

## Testing
- `npm test` *(fails: npm cannot access network)*

------
https://chatgpt.com/codex/tasks/task_e_686ac2606fcc83228fae7f303846a35c