### PR TITLE
Use context in dashboard certificates

### DIFF
--- a/src/components/dashboard/DashboardExperiences.js
+++ b/src/components/dashboard/DashboardExperiences.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useExperiences } from '../../context/ExperiencesContext';
 import '../../pages/DashboardPage.css';
 
@@ -17,6 +17,7 @@ const DashboardExperiences = () => {
     addExperience,
     updateExperienceById,
     deleteExperienceById,
+    loadExperiences,
   } = useExperiences();
 
   const [isAdding, setIsAdding] = useState(false);
@@ -24,6 +25,13 @@ const DashboardExperiences = () => {
   const [editingId, setEditingId] = useState(null);
   const [notification, setNotification] = useState(null);
   const [confirmDelete, setConfirmDelete] = useState(null);
+
+  useEffect(() => {
+    if (experiences.length === 0) {
+      loadExperiences();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const showNotification = (message, type = 'success') => {
     setNotification({ message, type });

--- a/src/components/dashboard/DashboardProjects.js
+++ b/src/components/dashboard/DashboardProjects.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useProjects } from '../../context/ProjectsContext';
 import '../../pages/DashboardPage.css';
 
@@ -17,6 +17,7 @@ const DashboardProjects = () => {
     addProject,
     updateProjectById,
     deleteProjectById,
+    loadProjects,
   } = useProjects();
 
   const [isAdding, setIsAdding] = useState(false);
@@ -24,6 +25,13 @@ const DashboardProjects = () => {
   const [editingId, setEditingId] = useState(null);
   const [notification, setNotification] = useState(null);
   const [confirmDelete, setConfirmDelete] = useState(null);
+
+  useEffect(() => {
+    if (projects.length === 0) {
+      loadProjects();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const showNotification = (message, type = 'success') => {
     setNotification({ message, type });

--- a/src/components/dashboard/ProblemsSection.js
+++ b/src/components/dashboard/ProblemsSection.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useProblems } from '../../context/ProblemsContext';
 import '../../pages/DashboardPage.css';
 
@@ -20,6 +20,7 @@ function ProblemsSection() {
     addProblem,
     updateProblem,
     deleteProblemById,
+    loadProblems,
   } = useProblems();
 
   const [isAdding, setIsAdding] = useState(false);
@@ -27,6 +28,13 @@ function ProblemsSection() {
   const [editingId, setEditingId] = useState(null);
   const [notification, setNotification] = useState(null);
   const [confirmDelete, setConfirmDelete] = useState(null);
+
+  useEffect(() => {
+    if (problems.length === 0) {
+      loadProblems();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const showNotification = (message, type = 'success') => {
     setNotification({ message, type });


### PR DESCRIPTION
## Summary
- remove local certificate state
- pull data and actions from `useCertificates`
- only fetch certificates on mount when needed
- update add/edit/delete actions to use context
- load experience, project, and problem data on mount
