### PR TITLE
Remove redundant data fetching hooks

### DIFF
--- a/src/components/dashboard/DashboardCertificates.js
+++ b/src/components/dashboard/DashboardCertificates.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useAuth } from '../../context/AuthContext';
 import { useCertificates } from '../../context/CertificatesContext';
 import '../../pages/DashboardPage.css';
@@ -9,7 +9,6 @@ const DashboardCertificates = () => {
     certificates,
     loading,
     error,
-    loadCertificates,
     addCertificate,
     updateCertificateById,
     deleteCertificateById,
@@ -31,12 +30,6 @@ const DashboardCertificates = () => {
 
   const categories = ['Development', 'Data', 'Cloud', 'Design', 'Other'];
 
-  useEffect(() => {
-    if (certificates.length === 0) {
-      loadCertificates();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const currentDate = new Date();
   const hours = currentDate.getHours();

--- a/src/components/dashboard/DashboardExperiences.js
+++ b/src/components/dashboard/DashboardExperiences.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useExperiences } from '../../context/ExperiencesContext';
 import '../../pages/DashboardPage.css';
 
@@ -17,7 +17,6 @@ const DashboardExperiences = () => {
     addExperience,
     updateExperienceById,
     deleteExperienceById,
-    loadExperiences,
   } = useExperiences();
 
   const [isAdding, setIsAdding] = useState(false);
@@ -26,12 +25,6 @@ const DashboardExperiences = () => {
   const [notification, setNotification] = useState(null);
   const [confirmDelete, setConfirmDelete] = useState(null);
 
-  useEffect(() => {
-    if (experiences.length === 0) {
-      loadExperiences();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const showNotification = (message, type = 'success') => {
     setNotification({ message, type });

--- a/src/components/dashboard/DashboardProjects.js
+++ b/src/components/dashboard/DashboardProjects.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useProjects } from '../../context/ProjectsContext';
 import '../../pages/DashboardPage.css';
 
@@ -17,7 +17,6 @@ const DashboardProjects = () => {
     addProject,
     updateProjectById,
     deleteProjectById,
-    loadProjects,
   } = useProjects();
 
   const [isAdding, setIsAdding] = useState(false);
@@ -26,12 +25,6 @@ const DashboardProjects = () => {
   const [notification, setNotification] = useState(null);
   const [confirmDelete, setConfirmDelete] = useState(null);
 
-  useEffect(() => {
-    if (projects.length === 0) {
-      loadProjects();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const showNotification = (message, type = 'success') => {
     setNotification({ message, type });

--- a/src/components/dashboard/ProblemsSection.js
+++ b/src/components/dashboard/ProblemsSection.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useProblems } from '../../context/ProblemsContext';
 import '../../pages/DashboardPage.css';
 
@@ -20,7 +20,6 @@ function ProblemsSection() {
     addProblem,
     updateProblem,
     deleteProblemById,
-    loadProblems,
   } = useProblems();
 
   const [isAdding, setIsAdding] = useState(false);
@@ -29,12 +28,6 @@ function ProblemsSection() {
   const [notification, setNotification] = useState(null);
   const [confirmDelete, setConfirmDelete] = useState(null);
 
-  useEffect(() => {
-    if (problems.length === 0) {
-      loadProblems();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const showNotification = (message, type = 'success') => {
     setNotification({ message, type });


### PR DESCRIPTION
## Summary
- avoid duplicate data loading in dashboard sections

## Testing
- `npm test` *(fails: unable to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686acf35bd7883229c8d67d4e11cb809