### PR TITLE
Add signup page & guest login button

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import ExperiencePage from './pages/ExperiencePage';
 import ContactPage from './pages/ContactPage';
 import ChatPage from './pages/ChatPage';
 import LoginPage from './pages/LoginPage';
+import SignupPage from './pages/SignupPage';
 import DashboardPage from './pages/DashboardPage';
 import NotFoundPage from './pages/NotFoundPage';
 import ResumeAndCoverPage from './pages/ResumeAndCoverPage';
@@ -39,6 +40,7 @@ function App() {
           <Route path="/contact" element={<ContactPage />} />
           <Route path="/chat" element={<ChatPage />} />
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/signup" element={<SignupPage />} />
           <Route path="/resume-and-cover" element={<ResumeAndCoverPage />} />
 
           {/* <Route

--- a/frontend/src/components/layout/Header.js
+++ b/frontend/src/components/layout/Header.js
@@ -100,11 +100,18 @@ const Header = () => {
                   </li>
                 </>
               ) : (
-                <li className="nav-item">
-                  <NavLink to="/login" className="button">
-                    Login
-                  </NavLink>
-                </li>
+                <>
+                  <li className="nav-item">
+                    <NavLink to="/signup" className="button outline">
+                      Sign Up
+                    </NavLink>
+                  </li>
+                  <li className="nav-item">
+                    <NavLink to="/login" className="button">
+                      Login
+                    </NavLink>
+                  </li>
+                </>
               )}
               
               <li className="nav-item theme-toggle">

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -76,12 +76,27 @@ export const AuthProvider = ({ children }) => {
     return { success: false, error: 'Invalid credentials' };
   };
 
+  const signup = (fullName, email, password) => {
+    if (email && password) {
+      setUser({
+        id: Date.now().toString(),
+        email,
+        name: fullName,
+        role: 'guest'
+      });
+      setToken('guest-token');
+      return { success: true, token: 'guest-token' };
+    }
+
+    return { success: false, error: 'Invalid details' };
+  };
+
   const logout = () => {
     setUser(null);
   };
 
   return (
-    <AuthContext.Provider value={{ user, token, login, logout, isLoading, verificationCode }}>
+    <AuthContext.Provider value={{ user, token, login, signup, logout, isLoading, verificationCode }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate, Navigate } from 'react-router-dom';
+import { useNavigate, Navigate, Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import './LoginPage.css';
 
@@ -9,7 +9,6 @@ const LoginPage = () => {
   const [verificationCode, setVerificationCode] = useState('');
   const [isVerifying, setIsVerifying] = useState(false);
   const [error, setError] = useState('');
-  const [isGuestMode, setIsGuestMode] = useState(false);
   const { user, login } = useAuth();
   const navigate = useNavigate();
 
@@ -27,12 +26,12 @@ const LoginPage = () => {
       return;
     }
 
-    if (!isGuestMode && !password) {
+    if (!password) {
       setError('Password is required');
       return;
     }
 
-    const result = login(email, isGuestMode ? 'guest123' : password, isVerifying ? verificationCode : null);
+    const result = login(email, password, isVerifying ? verificationCode : null);
 
     if (result.success) {
       if (result.requireVerification) {
@@ -45,10 +44,11 @@ const LoginPage = () => {
     }
   };
 
-  const toggleGuestMode = () => {
-    setIsGuestMode(!isGuestMode);
-    setError('');
+  const handleGuestLogin = () => {
+    login('guest@example.com', 'guest123');
+    navigate('/');
   };
+
 
   return (
     <div className="login-page">
@@ -75,37 +75,28 @@ const LoginPage = () => {
                   />
                 </div>
                 
-                {!isGuestMode && (
-                  <div className="form-group">
-                    <label htmlFor="password">Password</label>
-                    <input
-                      type="password"
-                      id="password"
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      placeholder="Enter your password"
-                    />
-                  </div>
-                )}
+              <div className="form-group">
+                <label htmlFor="password">Password</label>
+                <input
+                  type="password"
+                  id="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Enter your password"
+                />
+              </div>
                 
                 <button type="submit" className="button login-button">
-                  {isGuestMode ? 'Continue as Guest' : 'Sign In'}
+                  Sign In
                 </button>
                 
                 <div className="form-footer">
-                  <button 
-                    type="button" 
-                    className="link-button"
-                    onClick={toggleGuestMode}
-                  >
-                    {isGuestMode ? 'I have an account' : 'Only need to look around?'}
+                  <Link to="/signup" className="link-button">
+                    Create account
+                  </Link>
+                  <button type="button" className="link-button">
+                    Forgot password?
                   </button>
-                  
-                  {!isGuestMode && (
-                    <button type="button" className="link-button">
-                      Forgot password?
-                    </button>
-                  )}
                 </div>
               </>
             ) : (
@@ -142,6 +133,12 @@ const LoginPage = () => {
               </>
             )}
           </form>
+
+          <div className="guest-login">
+            <button type="button" className="button" onClick={handleGuestLogin}>
+              Continue as Guest
+            </button>
+          </div>
           
           <div className="legal-text">
             <p>By continuing you agree to the site's Cookie and Privacy policies.</p>

--- a/frontend/src/pages/SignupPage.css
+++ b/frontend/src/pages/SignupPage.css
@@ -1,11 +1,11 @@
-.login-page {
+.signup-page {
   padding-top: 120px;
   min-height: 100vh;
   display: flex;
   align-items: center;
 }
 
-.login-container {
+.signup-container {
   max-width: 480px;
   margin: 0 auto;
   padding: var(--space-8);
@@ -15,18 +15,14 @@
   border: 1px solid var(--border);
 }
 
-.login-header {
+.signup-header {
   text-align: center;
   margin-bottom: var(--space-8);
 }
 
-.login-header h1 {
+.signup-header h1 {
   font-size: var(--text-3xl);
   margin-bottom: var(--space-2);
-}
-
-.login-header p {
-  color: var(--muted-foreground);
 }
 
 .alert {
@@ -41,7 +37,7 @@
   color: var(--error-700);
 }
 
-.login-form {
+.signup-form {
   margin-bottom: var(--space-6);
 }
 
@@ -70,7 +66,7 @@
   outline: none;
 }
 
-.login-button {
+.signup-button {
   width: 100%;
   padding: var(--space-3) var(--space-4);
   margin-top: var(--space-4);
@@ -79,7 +75,7 @@
 
 .form-footer {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   margin-top: var(--space-4);
 }
 
@@ -100,34 +96,14 @@
   transform: none;
 }
 
-.verification-info {
-  margin-bottom: var(--space-6);
-  padding: var(--space-4);
-  background-color: var(--primary-50);
-  border-radius: var(--radius-md);
-  color: var(--primary-700);
-}
-
-.legal-text {
-  text-align: center;
-  font-size: var(--text-xs);
-  color: var(--muted-foreground);
-}
-
 .guest-login {
   margin-top: var(--space-6);
   text-align: center;
 }
 
 @media (max-width: 768px) {
-  .login-container {
+  .signup-container {
     padding: var(--space-6);
     margin: 0 var(--space-4);
-  }
-  
-  .form-footer {
-    flex-direction: column;
-    gap: var(--space-3);
-    align-items: center;
   }
 }

--- a/frontend/src/pages/SignupPage.js
+++ b/frontend/src/pages/SignupPage.js
@@ -1,0 +1,127 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import './SignupPage.css';
+
+const SignupPage = () => {
+  const [fullName, setFullName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const { signup } = useAuth();
+  const navigate = useNavigate();
+
+  const validatePassword = (pw) => {
+    const regex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@#$%&*]).{8,}$/;
+    return regex.test(pw);
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setError('');
+
+    if (!fullName || !email || !password || !confirmPassword) {
+      setError('All fields are required');
+      return;
+    }
+
+    if (!validatePassword(password)) {
+      setError(
+        'Password must be at least 8 characters and include uppercase, lowercase, number and symbol.'
+      );
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    signup(fullName, email, password);
+    navigate('/');
+  };
+
+  const handleGuest = () => {
+    signup('Guest User', 'guest@example.com', 'guest123');
+    navigate('/');
+  };
+
+  return (
+    <div className="signup-page">
+      <div className="container">
+        <div className="signup-container">
+          <div className="signup-header">
+            <h1>Create Account</h1>
+          </div>
+
+          {error && <div className="alert alert-error">{error}</div>}
+
+          <form onSubmit={handleSubmit} className="signup-form">
+            <div className="form-group">
+              <label htmlFor="fullName">Full Name</label>
+              <input
+                type="text"
+                id="fullName"
+                value={fullName}
+                onChange={(e) => setFullName(e.target.value)}
+                placeholder="Enter your full name"
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="email">Email address</label>
+              <input
+                type="email"
+                id="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="Enter your email"
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="password">Password</label>
+              <input
+                type="password"
+                id="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Enter your password"
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="confirmPassword">Confirm Password</label>
+              <input
+                type="password"
+                id="confirmPassword"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                placeholder="Confirm your password"
+              />
+            </div>
+
+            <button type="submit" className="button signup-button">
+              Sign Up
+            </button>
+          </form>
+
+          <div className="form-footer">
+            <Link to="/login" className="link-button">
+              Already have an account?
+            </Link>
+          </div>
+
+          <div className="guest-login">
+            <button type="button" className="button" onClick={handleGuest}>
+              Continue as Guest
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SignupPage;


### PR DESCRIPTION
## Summary
- create a new `SignupPage` with password validation and guest option
- expose new `signup` helper in `AuthContext`
- adjust `LoginPage` to use a guest login button
- wire `/signup` route and update header navigation

## Testing
- `npm test` *(fails: npm install requires network)*

------
https://chatgpt.com/codex/tasks/task_e_686adbc61af083229176640d493bedb8