### PR TITLE
Switch certificate modal image to background style

### DIFF
--- a/frontend/src/pages/CertificationsPage.css
+++ b/frontend/src/pages/CertificationsPage.css
@@ -216,12 +216,8 @@
   width: 100%;
   height: 300px;
   overflow: hidden;
-}
-
-.certificate-modal-image img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  background-size: cover;
+  background-position: center;
 }
 
 .certificate-placeholder.large {

--- a/frontend/src/pages/CertificationsPage.js
+++ b/frontend/src/pages/CertificationsPage.js
@@ -114,10 +114,11 @@ const CertificationsPage = () => {
             <div className="certificate-modal-content" onClick={e => e.stopPropagation()}>
               <button className="close-button" onClick={() => setSelectedCertificate(null)}>×</button>
               
-              <div className="certificate-modal-image">
-                {selectedCertificate.imageUrl ? (
-                  <img src={selectedCertificate.imageUrl} alt={selectedCertificate.title} />
-                ) : (
+              <div
+                className="certificate-modal-image"
+                style={selectedCertificate.imageUrl ? { backgroundImage: `url(${selectedCertificate.imageUrl})` } : {}}
+              >
+                {!selectedCertificate.imageUrl && (
                   <div className="certificate-placeholder large">
                     <span>No Image Available</span>
                   </div>


### PR DESCRIPTION
## Summary
- use CSS background for certificate image in modal
- style modal image container for centered cover display

## Testing
- `npm test --silent` *(fails: 403 Forbidden)*
- `npx jest --maxWorkers=2` *(fails: 403 Forbidden)*
- `npm run lint --silent` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_686cabf1bd008322bc22d224045c3874