### PR TITLE
Move API URLs to env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 coverage/
 target/
+.env

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ cd frontend
 npm run lint
 ```
 
-The React app reads `REACT_APP_API_BASE_URL` to know where the Node API is running. Set this variable before starting the dev server or building the project so API calls are proxied correctly.
+The React app reads `REACT_APP_API_BASE_URL` to know where the Node API is running. Create a `.env` file inside `frontend/` and set this variable before starting the dev server or building the project so API calls are proxied correctly.
 
 ## Node Backend
 
-`backend-node/` contains a minimal Express server exposing `/login`, `/certificates` and `/leetcode` routes. The `/login` endpoint accepts a **POST** request with a JSON body containing `email` and `password` fields. The route forwards these credentials to the Java backend and returns whatever response it provides. Configure the Java backend's base URL via the `JAVA_BASE_URL` environment variable (defaults to `http://localhost:8080`).
+`backend-node/` contains a minimal Express server exposing `/login`, `/certificates` and `/leetcode` routes. The `/login` endpoint accepts a **POST** request with a JSON body containing `email` and `password` fields. The route forwards these credentials to the Java backend and returns whatever response it provides. Create a `.env` file inside `backend-node/` and configure the Java backend's base URL via the `JAVA_BASE_URL` variable (defaults to `http://localhost:8080`).
 
 ```sh
 cd backend-node

--- a/backend-node/.env.example
+++ b/backend-node/.env.example
@@ -1,0 +1,2 @@
+JAVA_BASE_URL=http://localhost:8080
+PORT=3001

--- a/backend-node/index.js
+++ b/backend-node/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
+require('dotenv').config();
 
 const app = express();
 app.use(cors());

--- a/backend-node/package.json
+++ b/backend-node/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "cors": "^2.8.5",
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
+    "dotenv": "^10.0.0"
   }
 }

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE_URL=http://localhost:3001


### PR DESCRIPTION
## Summary
- load environment variables in Node backend
- add dotenv dependency for Node
- provide `.env.example` files for frontend and backend
- document environment variables in README
- ignore real `.env` files