### PR TITLE
Handle 204 responses for delete APIs

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -60,6 +60,9 @@ export async function deleteCertificate(id) {
   const response = await fetch(`${API_BASE_URL}/certificates/${id}`, {
     method: 'DELETE'
   });
+  if (response.status === 204) {
+    return true;
+  }
   if (!response.ok) {
     throw new Error('Failed to delete certificate');
   }
@@ -118,6 +121,9 @@ export async function deleteLeetcodeProblem(id) {
   const response = await fetch(`${API_BASE_URL}/leetcode/${id}`, {
     method: 'DELETE'
   });
+  if (response.status === 204) {
+    return true;
+  }
   if (!response.ok) {
     throw new Error('Failed to delete problem');
   }
@@ -152,6 +158,9 @@ export async function deleteExperience(id) {
   const response = await fetch(`${API_BASE_URL}/experiences/${id}`, {
     method: 'DELETE'
   });
+  if (response.status === 204) {
+    return true;
+  }
   if (!response.ok) {
     throw new Error('Failed to delete experience');
   }
@@ -186,6 +195,9 @@ export async function deleteProject(id) {
   const response = await fetch(`${API_BASE_URL}/projects/${id}`, {
     method: 'DELETE'
   });
+  if (response.status === 204) {
+    return true;
+  }
   if (!response.ok) {
     throw new Error('Failed to delete project');
   }


### PR DESCRIPTION
## Summary
- return `true` when the API responds with HTTP 204 for delete helpers

## Testing
- `npm test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686ce02053808322a28593bc5500ad10