### PR TITLE
Improve signup error handling

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -502,3 +502,11 @@ section {
   background-color: var(--success-500);
   color: #fff;
 }
+.Toastify__toast--warning {
+  background-color: var(--warning-500);
+  color: #fff;
+}
+.Toastify__toast--error {
+  background-color: var(--error-500);
+  color: #fff;
+}

--- a/frontend/src/pages/SignupPage.js
+++ b/frontend/src/pages/SignupPage.js
@@ -40,18 +40,18 @@ const SignupPage = () => {
       return;
     }
 
-    signup(fullName, email, password);
     try {
       const data = await apiSignup(fullName, email, password);
+      signup(fullName, email, password);
       if (data.message) {
         toast.success(data.message);
       } else {
         toast.success('Signup successful');
       }
+      navigate('/');
     } catch (err) {
-      toast.success(`Welcome, ${fullName}!`);
+      toast.warn(err.message);
     }
-    navigate('/');
   };
 
   const handleGuest = () => {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -19,10 +19,11 @@ export async function signup(fullName, email, password) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ fullName, email, password })
   });
+  const data = await response.json().catch(() => ({}));
   if (!response.ok) {
-    throw new Error('Failed to signup');
+    throw new Error(data.error || 'Failed to signup');
   }
-  return response.json();
+  return data;
 }
 
 export async function fetchCertificates() {


### PR DESCRIPTION
## Summary
- surface signup API error messages in `signup` helper
- call signup only after successful API call
- keep user on the signup form and show warning toast on failure
- style warning/error toasts in the main CSS

## Testing
- `npm test` *(fails: 403 Forbidden to npm registry)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686ce1b1ee708322852f936620431c9d