### PR TITLE
Add project and leetcode CRUD support

### DIFF
--- a/backend-java/src/main/java/com/example/demo/controller/LeetcodeController.java
+++ b/backend-java/src/main/java/com/example/demo/controller/LeetcodeController.java
@@ -1,0 +1,57 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.ProblemEntity;
+import com.example.demo.repository.ProblemRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/leetcode")
+public class LeetcodeController {
+
+    private final ProblemRepository problemRepository;
+
+    public LeetcodeController(ProblemRepository problemRepository) {
+        this.problemRepository = problemRepository;
+    }
+
+    @GetMapping
+    public List<ProblemEntity> getAll() {
+        return problemRepository.findAll();
+    }
+
+    @PostMapping
+    public ResponseEntity<ProblemEntity> create(@RequestBody ProblemEntity problem) {
+        ProblemEntity saved = problemRepository.save(problem);
+        return ResponseEntity.ok(saved);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ProblemEntity> update(@PathVariable Long id, @RequestBody ProblemEntity problem) {
+        Optional<ProblemEntity> existingOpt = problemRepository.findById(id);
+        if (existingOpt.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        ProblemEntity existing = existingOpt.get();
+        existing.setLcId(problem.getLcId());
+        existing.setTitle(problem.getTitle());
+        existing.setDifficulty(problem.getDifficulty());
+        existing.setLink(problem.getLink());
+        existing.setStatement(problem.getStatement());
+        existing.setSolution(problem.getSolution());
+        ProblemEntity saved = problemRepository.save(existing);
+        return ResponseEntity.ok(saved);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        if (!problemRepository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        problemRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend-java/src/main/java/com/example/demo/controller/ProjectController.java
+++ b/backend-java/src/main/java/com/example/demo/controller/ProjectController.java
@@ -1,0 +1,55 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.ProjectEntity;
+import com.example.demo.repository.ProjectRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/projects")
+public class ProjectController {
+
+    private final ProjectRepository projectRepository;
+
+    public ProjectController(ProjectRepository projectRepository) {
+        this.projectRepository = projectRepository;
+    }
+
+    @GetMapping
+    public List<ProjectEntity> getAll() {
+        return projectRepository.findAll();
+    }
+
+    @PostMapping
+    public ResponseEntity<ProjectEntity> create(@RequestBody ProjectEntity project) {
+        ProjectEntity saved = projectRepository.save(project);
+        return ResponseEntity.ok(saved);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ProjectEntity> update(@PathVariable Long id, @RequestBody ProjectEntity project) {
+        Optional<ProjectEntity> existingOpt = projectRepository.findById(id);
+        if (existingOpt.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        ProjectEntity existing = existingOpt.get();
+        existing.setTitle(project.getTitle());
+        existing.setDescription(project.getDescription());
+        existing.setImageUrl(project.getImageUrl());
+        existing.setTechnologies(project.getTechnologies());
+        ProjectEntity saved = projectRepository.save(existing);
+        return ResponseEntity.ok(saved);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        if (!projectRepository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        projectRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend-java/src/main/java/com/example/demo/model/ProblemEntity.java
+++ b/backend-java/src/main/java/com/example/demo/model/ProblemEntity.java
@@ -1,0 +1,78 @@
+package com.example.demo.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "leetcode_problems")
+public class ProblemEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String lcId;
+    private String title;
+    private String difficulty;
+    private String link;
+
+    @Column(columnDefinition = "text")
+    private String statement;
+
+    @Embedded
+    private Solution solution = new Solution();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getLcId() {
+        return lcId;
+    }
+
+    public void setLcId(String lcId) {
+        this.lcId = lcId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDifficulty() {
+        return difficulty;
+    }
+
+    public void setDifficulty(String difficulty) {
+        this.difficulty = difficulty;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public void setLink(String link) {
+        this.link = link;
+    }
+
+    public String getStatement() {
+        return statement;
+    }
+
+    public void setStatement(String statement) {
+        this.statement = statement;
+    }
+
+    public Solution getSolution() {
+        return solution;
+    }
+
+    public void setSolution(Solution solution) {
+        this.solution = solution;
+    }
+}

--- a/backend-java/src/main/java/com/example/demo/model/ProjectEntity.java
+++ b/backend-java/src/main/java/com/example/demo/model/ProjectEntity.java
@@ -1,0 +1,59 @@
+package com.example.demo.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "projects")
+public class ProjectEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Column(columnDefinition = "text")
+    private String description;
+
+    private String imageUrl;
+    private String technologies;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public String getTechnologies() {
+        return technologies;
+    }
+
+    public void setTechnologies(String technologies) {
+        this.technologies = technologies;
+    }
+}

--- a/backend-java/src/main/java/com/example/demo/model/Solution.java
+++ b/backend-java/src/main/java/com/example/demo/model/Solution.java
@@ -1,0 +1,29 @@
+package com.example.demo.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Solution {
+    @Column(name = "solution_js", columnDefinition = "text")
+    private String javascript;
+
+    @Column(name = "solution_python", columnDefinition = "text")
+    private String python;
+
+    public String getJavascript() {
+        return javascript;
+    }
+
+    public void setJavascript(String javascript) {
+        this.javascript = javascript;
+    }
+
+    public String getPython() {
+        return python;
+    }
+
+    public void setPython(String python) {
+        this.python = python;
+    }
+}

--- a/backend-java/src/main/java/com/example/demo/repository/ProblemRepository.java
+++ b/backend-java/src/main/java/com/example/demo/repository/ProblemRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.ProblemEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemRepository extends JpaRepository<ProblemEntity, Long> {
+}

--- a/backend-java/src/main/java/com/example/demo/repository/ProjectRepository.java
+++ b/backend-java/src/main/java/com/example/demo/repository/ProjectRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.ProjectEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<ProjectEntity, Long> {
+}


### PR DESCRIPTION
## Summary
- implement `ProjectEntity` and `ProblemEntity` JPA entities
- add JPA repositories for the new entities
- create `ProjectController` exposing `/api/projects`
- create `LeetcodeController` exposing `/api/leetcode`

## Testing
- `./gradlew test --quiet` *(fails: Plugin not found due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_686cf97df4048322ab64e0d9d6977ade