### PR TITLE
Load dashboard data on demand

### DIFF
--- a/frontend/src/components/dashboard/DashboardCertificates.js
+++ b/frontend/src/components/dashboard/DashboardCertificates.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useAuth } from '../../context/AuthContext';
 import { useCertificates } from '../../context/CertificatesContext';
 import '../../pages/DashboardPage.css';
@@ -12,7 +12,12 @@ const DashboardCertificates = () => {
     addCertificate,
     updateCertificateById,
     deleteCertificateById,
+    loadCertificates,
   } = useCertificates();
+
+  useEffect(() => {
+    loadCertificates();
+  }, []);
   const [newCertificate, setNewCertificate] = useState({
     title: '',
     issuer: '',

--- a/frontend/src/components/dashboard/DashboardExperiences.js
+++ b/frontend/src/components/dashboard/DashboardExperiences.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useExperiences } from '../../context/ExperiencesContext';
 import '../../pages/DashboardPage.css';
 
@@ -22,7 +22,12 @@ const DashboardExperiences = () => {
     addExperience,
     updateExperienceById,
     deleteExperienceById,
+    loadExperiences,
   } = useExperiences();
+
+  useEffect(() => {
+    loadExperiences();
+  }, []);
 
   const [isAdding, setIsAdding] = useState(false);
   const [formData, setFormData] = useState(initialForm);

--- a/frontend/src/components/dashboard/DashboardProjects.js
+++ b/frontend/src/components/dashboard/DashboardProjects.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useProjects } from '../../context/ProjectsContext';
 import '../../pages/DashboardPage.css';
 
@@ -17,7 +17,12 @@ const DashboardProjects = () => {
     addProject,
     updateProjectById,
     deleteProjectById,
+    loadProjects,
   } = useProjects();
+
+  useEffect(() => {
+    loadProjects();
+  }, []);
 
   const [isAdding, setIsAdding] = useState(false);
   const [formData, setFormData] = useState(initialForm);

--- a/frontend/src/components/dashboard/ProblemsSection.js
+++ b/frontend/src/components/dashboard/ProblemsSection.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useProblems } from '../../context/ProblemsContext';
 import '../../pages/DashboardPage.css';
 
@@ -20,7 +20,12 @@ function ProblemsSection() {
     addProblem,
     updateProblem,
     deleteProblemById,
+    loadProblems,
   } = useProblems();
+
+  useEffect(() => {
+    loadProblems();
+  }, []);
 
   const [isAdding, setIsAdding] = useState(false);
   const [formData, setFormData] = useState(initialForm);

--- a/frontend/src/context/CertificatesContext.js
+++ b/frontend/src/context/CertificatesContext.js
@@ -87,9 +87,7 @@ export const CertificatesProvider = ({ children }) => {
     }
   };
 
-  useEffect(() => {
-    loadCertificates();
-  }, []);
+  // Data is loaded on demand from the dashboard pages
 
   return (
     <CertificatesContext.Provider

--- a/frontend/src/context/ExperiencesContext.js
+++ b/frontend/src/context/ExperiencesContext.js
@@ -87,9 +87,7 @@ export const ExperiencesProvider = ({ children }) => {
     }
   };
 
-  useEffect(() => {
-    loadExperiences();
-  }, []);
+  // Data is loaded on demand from the dashboard pages
 
   return (
     <ExperiencesContext.Provider

--- a/frontend/src/context/ProblemsContext.js
+++ b/frontend/src/context/ProblemsContext.js
@@ -87,9 +87,7 @@ export const ProblemsProvider = ({ children }) => {
     }
   };
 
-  useEffect(() => {
-    loadProblems();
-  }, []);
+  // Data is loaded on demand from the dashboard pages
 
   return (
     <ProblemsContext.Provider

--- a/frontend/src/context/ProjectsContext.js
+++ b/frontend/src/context/ProjectsContext.js
@@ -87,9 +87,7 @@ export const ProjectsProvider = ({ children }) => {
     }
   };
 
-  useEffect(() => {
-    loadProjects();
-  }, []);
+  // Data is loaded on demand from the dashboard pages
 
   return (
     <ProjectsContext.Provider


### PR DESCRIPTION
## Summary
- remove automatic API calls from dashboard context providers
- fetch certificates, experience, projects and leetcode data only when their tab mounts

## Testing
- `npm test --silent` *(fails: network access blocked)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686cfc13228883229c70aeb9d8116fd2