### PR TITLE
Add -parameters compiler flag

### DIFF
--- a/backend-java/build.gradle
+++ b/backend-java/build.gradle
@@ -22,3 +22,7 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += '-parameters'
+}


### PR DESCRIPTION
## Summary
- ensure Java controller methods retain parameter names by passing `-parameters`