### PR TITLE
Add document upload feature

### DIFF
--- a/backend-java/src/main/java/com/example/demo/controller/DocumentController.java
+++ b/backend-java/src/main/java/com/example/demo/controller/DocumentController.java
@@ -1,0 +1,82 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.DocumentEntity;
+import com.example.demo.repository.DocumentRepository;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.time.Instant;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/documents")
+public class DocumentController {
+
+    private final DocumentRepository documentRepository;
+    private final Path uploadDir = Paths.get("uploads");
+
+    public DocumentController(DocumentRepository documentRepository) throws IOException {
+        this.documentRepository = documentRepository;
+        Files.createDirectories(uploadDir);
+    }
+
+    @PostMapping(path = "/{type}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> upload(@PathVariable("type") String type, @RequestParam("file") MultipartFile file) {
+        if (!"resume".equalsIgnoreCase(type) && !"coverletter".equalsIgnoreCase(type)) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Invalid type"));
+        }
+        if (file.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "File required"));
+        }
+        try {
+            String original = file.getOriginalFilename();
+            String ext = "";
+            if (original != null && original.contains(".")) {
+                ext = original.substring(original.lastIndexOf('.'));
+            }
+            String storedName = type + "-" + System.currentTimeMillis() + ext;
+            Path target = uploadDir.resolve(storedName);
+            Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
+            DocumentEntity entity = new DocumentEntity();
+            entity.setType(type.toLowerCase());
+            entity.setFileName(storedName);
+            entity.setUploadedAt(Instant.now());
+            documentRepository.save(entity);
+            return ResponseEntity.ok(Map.of("fileName", storedName));
+        } catch (IOException e) {
+            return ResponseEntity.status(500).body(Map.of("error", "Failed to store file"));
+        }
+    }
+
+    @GetMapping(path = "/{type}")
+    public ResponseEntity<?> fetchLatest(@PathVariable("type") String type) {
+        if (!"resume".equalsIgnoreCase(type) && !"coverletter".equalsIgnoreCase(type)) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Invalid type"));
+        }
+        DocumentEntity entity = documentRepository.findTopByTypeOrderByUploadedAtDesc(type.toLowerCase());
+        if (entity == null) {
+            return ResponseEntity.notFound().build();
+        }
+        Path filePath = uploadDir.resolve(entity.getFileName());
+        if (!Files.exists(filePath)) {
+            return ResponseEntity.notFound().build();
+        }
+        FileSystemResource resource = new FileSystemResource(filePath);
+        String contentType;
+        try {
+            contentType = Files.probeContentType(filePath);
+        } catch (IOException e) {
+            contentType = MediaType.APPLICATION_OCTET_STREAM_VALUE;
+        }
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + entity.getFileName())
+                .contentType(MediaType.parseMediaType(contentType != null ? contentType : MediaType.APPLICATION_OCTET_STREAM_VALUE))
+                .body(resource);
+    }
+}

--- a/backend-java/src/main/java/com/example/demo/model/DocumentEntity.java
+++ b/backend-java/src/main/java/com/example/demo/model/DocumentEntity.java
@@ -1,0 +1,52 @@
+package com.example.demo.model;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "documents")
+public class DocumentEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String type;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    private Instant uploadedAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public Instant getUploadedAt() {
+        return uploadedAt;
+    }
+
+    public void setUploadedAt(Instant uploadedAt) {
+        this.uploadedAt = uploadedAt;
+    }
+}

--- a/backend-java/src/main/java/com/example/demo/repository/DocumentRepository.java
+++ b/backend-java/src/main/java/com/example/demo/repository/DocumentRepository.java
@@ -1,0 +1,8 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.DocumentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DocumentRepository extends JpaRepository<DocumentEntity, Long> {
+    DocumentEntity findTopByTypeOrderByUploadedAtDesc(String type);
+}

--- a/backend-node/index.js
+++ b/backend-node/index.js
@@ -49,6 +49,39 @@ app.post('/signup', async (req, res) => {
   }
 });
 
+app.post('/documents/:type', async (req, res) => {
+  try {
+    const response = await fetch(`${JAVA_BASE_URL}/api/documents/${req.params.type}`, {
+      method: 'POST',
+      headers: { 'content-type': req.headers['content-type'] },
+      body: req
+    });
+    res.status(response.status);
+    response.headers.forEach((v, k) => res.setHeader(k, v));
+    response.body.pipe(res);
+  } catch (err) {
+    console.error('Error contacting Java backend:', err);
+    res.status(500).json({ error: 'Java backend unreachable' });
+  }
+});
+
+app.get('/documents/:type', async (req, res) => {
+  try {
+    const response = await fetch(`${JAVA_BASE_URL}/api/documents/${req.params.type}`);
+    res.status(response.status);
+    response.headers.forEach((v, k) => res.setHeader(k, v));
+    if (response.status === 200) {
+      response.body.pipe(res);
+    } else {
+      const data = await response.json();
+      res.json(data);
+    }
+  } catch (err) {
+    console.error('Error contacting Java backend:', err);
+    res.status(500).json({ error: 'Java backend unreachable' });
+  }
+});
+
 app.get('/certificates', async (req, res) => {
   try {
     const response = await fetch(`${JAVA_BASE_URL}/api/certificates`);


### PR DESCRIPTION
## Summary
- add JPA entity and repository for uploaded documents
- allow uploading and fetching documents in the Java backend
- proxy `/documents/:type` endpoints from the Node backend
- keep uploads directory in version control

## Testing
- `./gradlew test` *(fails: Plugin not found due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_686d0dad63ec8322945f6f4c2d9b7146