### PR TITLE
Implement documents list endpoint

### DIFF
--- a/backend-java/src/main/java/com/example/demo/controller/DocumentController.java
+++ b/backend-java/src/main/java/com/example/demo/controller/DocumentController.java
@@ -26,6 +26,11 @@ public class DocumentController {
         Files.createDirectories(uploadDir);
     }
 
+    @GetMapping("")
+    public ResponseEntity<?> getAll() {
+        return ResponseEntity.ok(documentRepository.findAll());
+    }
+
     @PostMapping(path = "/{type}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> upload(@PathVariable("type") String type, @RequestParam("file") MultipartFile file) {
         if (!"resume".equalsIgnoreCase(type) && !"coverletter".equalsIgnoreCase(type)) {

--- a/backend-java/src/test/java/com/example/demo/controller/DocumentControllerTest.java
+++ b/backend-java/src/test/java/com/example/demo/controller/DocumentControllerTest.java
@@ -1,0 +1,42 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.DocumentEntity;
+import com.example.demo.repository.DocumentRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(DocumentController.class)
+class DocumentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DocumentRepository documentRepository;
+
+    @Test
+    void getAllDocumentsReturnsList() throws Exception {
+        DocumentEntity doc = new DocumentEntity();
+        doc.setId(1L);
+        doc.setType("resume");
+        doc.setFileName("file.pdf");
+        doc.setUploadedAt(Instant.now());
+        when(documentRepository.findAll()).thenReturn(List.of(doc));
+
+        mockMvc.perform(get("/api/documents"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1L))
+                .andExpect(jsonPath("$[0].type").value("resume"))
+                .andExpect(jsonPath("$[0].fileName").value("file.pdf"));
+    }
+}

--- a/backend-node/index.js
+++ b/backend-node/index.js
@@ -49,6 +49,17 @@ app.post('/signup', async (req, res) => {
   }
 });
 
+app.get('/documents', async (req, res) => {
+  try {
+    const response = await fetch(`${JAVA_BASE_URL}/api/documents`);
+    const data = await response.json();
+    res.status(response.status).json(data);
+  } catch (err) {
+    console.error('Error contacting Java backend:', err);
+    res.status(500).json({ error: 'Java backend unreachable' });
+  }
+});
+
 app.post('/documents/:type', async (req, res) => {
   try {
     const response = await fetch(`${JAVA_BASE_URL}/api/documents/${req.params.type}`, {


### PR DESCRIPTION
## Summary
- add GET `/api/documents` endpoint in `DocumentController`
- proxy `/documents` in Node backend to Java service
- test `DocumentController` list endpoint
