### PR TITLE
Load resume files from API

### DIFF
--- a/frontend/src/context/DocsContext.js
+++ b/frontend/src/context/DocsContext.js
@@ -1,5 +1,5 @@
 import { createContext, useContext, useReducer } from 'react';
-import { fetchDocs, uploadDocument } from '../services/api';
+import { fetchDocs, uploadDocument, fetchLatestDocument } from '../services/api';
 
 const DocsContext = createContext();
 
@@ -48,8 +48,18 @@ export const DocsProvider = ({ children }) => {
     }
   };
 
+  const fetchLatest = async (type) => {
+    try {
+      const url = await fetchLatestDocument(type);
+      return url;
+    } catch (err) {
+      dispatch({ type: 'FETCH_FAILURE', payload: err.message });
+      return null;
+    }
+  };
+
   return (
-    <DocsContext.Provider value={{ ...state, loadDocs, uploadDoc }}>
+    <DocsContext.Provider value={{ ...state, loadDocs, uploadDoc, fetchLatest }}>
       {children}
     </DocsContext.Provider>
   );

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -228,3 +228,13 @@ export async function uploadDocument(type, file) {
   }
   return data;
 }
+
+export async function fetchLatestDocument(type) {
+  const response = await fetch(`${API_BASE_URL}/documents/${type}`);
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || 'Failed to fetch document');
+  }
+  const blob = await response.blob();
+  return URL.createObjectURL(blob);
+}


### PR DESCRIPTION
## Summary
- add `fetchLatestDocument` helper to API service
- extend Docs context with `fetchLatest` function
- load resume and cover letter from backend in `ResumeAndCoverPage`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test --silent` *(fails: npm network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686d9015953c8322b5e06fd8d489a311