### PR TITLE
Add admin editing to certificates page

### DIFF
--- a/frontend/src/pages/CertificationsPage.js
+++ b/frontend/src/pages/CertificationsPage.js
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import './CertificationsPage.css';
+import DashboardCertificates from '../components/dashboard/DashboardCertificates';
+import { CertificatesProvider } from '../context/CertificatesContext';
 
 import defaultCertificates from '../data/certificates';
 import { fetchCertificates } from '../services/api';
@@ -17,6 +19,10 @@ const CertificationsPage = () => {
   const categories = ['All', 'Development', 'Data', 'Cloud', 'Design', 'Academic'];
 
   useEffect(() => {
+    if (user?.role === 'admin') {
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     fetchCertificates()
       .then((data) => setCertificates(data))
@@ -26,8 +32,20 @@ const CertificationsPage = () => {
         setCertificates(defaultCertificates);
       })
       .finally(() => setLoading(false));
-  }, []);
-  
+  }, [user]);
+
+  if (user?.role === 'admin') {
+    return (
+      <div className="certifications-page">
+        <div className="container">
+          <CertificatesProvider>
+            <DashboardCertificates />
+          </CertificatesProvider>
+        </div>
+      </div>
+    );
+  }
+
   const filteredCertificates = filter === 'All'
     ? certificates
     : certificates.filter(cert => cert.category === filter);

--- a/frontend/src/pages/CertificationsPage.test.js
+++ b/frontend/src/pages/CertificationsPage.test.js
@@ -1,0 +1,23 @@
+import { render, screen } from '../test-utils';
+import CertificationsPage from './CertificationsPage';
+import defaultCertificates from '../data/certificates';
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(defaultCertificates) });
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+  localStorage.clear();
+});
+
+test('renders admin dashboard when user is admin', async () => {
+  localStorage.setItem('user', JSON.stringify({ role: 'admin', name: 'Admin User' }));
+  render(<CertificationsPage />);
+  expect(await screen.findByRole('button', { name: /add new certificate/i })).toBeInTheDocument();
+});
+
+test('renders certificate grid for guests', async () => {
+  render(<CertificationsPage />);
+  expect(await screen.findByText(defaultCertificates[0].title)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- allow admin users to manage certificates directly from `/certifications`
- create tests for the new admin workflow

## Testing
- `npm test` *(fails: 403 Forbidden during package install)*

------
https://chatgpt.com/codex/tasks/task_e_686eab9f3df08322bf0ae835fa5c39ad