### PR TITLE
Clean up object URLs for latest documents

### DIFF
--- a/frontend/src/pages/ResumeAndCoverPage.js
+++ b/frontend/src/pages/ResumeAndCoverPage.js
@@ -26,6 +26,31 @@ const ResumeAndCoverPage = () => {
     coverLetter: `${process.env.PUBLIC_URL}/coverletter.pdf`,
   });
   const fetchedRef = useRef({});
+  const urlRef = useRef({
+    resume: null,
+    coverLetter: null,
+  });
+
+  useEffect(() => {
+    const prev = urlRef.current;
+    Object.entries(urls).forEach(([key, url]) => {
+      const oldUrl = prev[key];
+      if (oldUrl && oldUrl !== url && oldUrl.startsWith('blob:')) {
+        URL.revokeObjectURL(oldUrl);
+      }
+    });
+    urlRef.current = urls;
+  }, [urls]);
+
+  useEffect(() => {
+    return () => {
+      Object.values(urlRef.current).forEach((u) => {
+        if (u && u.startsWith('blob:')) {
+          URL.revokeObjectURL(u);
+        }
+      });
+    };
+  }, []);
 
   const showNotification = (message, type = 'success') => {
     setNotification({ message, type });


### PR DESCRIPTION
## Summary
- cleanup previously created object URLs in `DocsProvider`
- track and revoke blob URLs when replaced in `ResumeAndCoverPage`