### PR TITLE
Add cache headers in document fetch

### DIFF
--- a/backend-java/src/main/java/com/example/demo/controller/DocumentController.java
+++ b/backend-java/src/main/java/com/example/demo/controller/DocumentController.java
@@ -81,6 +81,8 @@ public class DocumentController {
         }
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + entity.getFileName())
+                .header(HttpHeaders.CACHE_CONTROL, "no-store, no-cache, must-revalidate")
+                .header(HttpHeaders.PRAGMA, "no-cache")
                 .contentType(MediaType.parseMediaType(contentType != null ? contentType : MediaType.APPLICATION_OCTET_STREAM_VALUE))
                 .body(resource);
     }

--- a/backend-java/src/test/java/com/example/demo/controller/DocumentControllerTest.java
+++ b/backend-java/src/test/java/com/example/demo/controller/DocumentControllerTest.java
@@ -94,6 +94,9 @@ class DocumentControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION,
                         "attachment; filename=" + fileName))
+                .andExpect(header().string(HttpHeaders.CACHE_CONTROL,
+                        "no-store, no-cache, must-revalidate"))
+                .andExpect(header().string(HttpHeaders.PRAGMA, "no-cache"))
                 .andExpect(content().string("content"));
 
         Files.deleteIfExists(filePath);


### PR DESCRIPTION
## Summary
- add Cache-Control and Pragma headers when fetching documents
- expect these headers in DocumentController tests

## Testing
- `./gradlew test --no-daemon` *(fails: could not resolve Spring Boot plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686ec4ed2cd883229b00c11f014ee491