### PR TITLE
Add admin project management to Experience page

### DIFF
--- a/frontend/src/pages/ExperiencePage.css
+++ b/frontend/src/pages/ExperiencePage.css
@@ -238,6 +238,153 @@
   margin-top: var(--space-4);
 }
 
+/* Project actions for admin */
+.project-actions {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  display: flex;
+  gap: var(--space-2);
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.project-card:hover .project-actions {
+  opacity: 1;
+}
+
+.icon-button {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-full);
+  background-color: var(--background);
+  box-shadow: var(--shadow-md);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.icon-button:hover {
+  background-color: var(--card);
+  transform: translateY(-2px);
+}
+
+.delete-button:hover {
+  background-color: var(--error-100);
+}
+
+.certificate-form-container {
+  background-color: var(--card);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-md);
+  border: 1px solid var(--border);
+  margin-top: var(--space-8);
+}
+
+.certificate-form-container h2 {
+  margin-bottom: var(--space-6);
+  font-size: var(--text-2xl);
+}
+
+.certificate-form {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-6);
+}
+
+.form-group {
+  margin-bottom: var(--space-4);
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: var(--space-2);
+  font-weight: 500;
+}
+
+.form-actions {
+  grid-column: span 2;
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.notification {
+  position: fixed;
+  bottom: var(--space-6);
+  right: var(--space-6);
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: var(--z-50);
+  animation: slideIn var(--transition-normal) forwards, fadeOut 0.5s 2.5s forwards;
+}
+
+.notification.success {
+  background-color: var(--success-100);
+  border-left: 4px solid var(--success-500);
+  color: var(--success-700);
+}
+
+.notification.error {
+  background-color: var(--error-100);
+  border-left: 4px solid var(--error-500);
+  color: var(--error-700);
+}
+
+.confirm-dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-50);
+}
+
+.confirm-dialog-content {
+  background-color: var(--background);
+  padding: var(--space-6);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  max-width: 500px;
+  width: 90%;
+}
+
+.confirm-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-4);
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
 /* Project Modal */
 .project-modal {
   position: fixed;


### PR DESCRIPTION
## Summary
- fetch projects/experiences on Experience page load
- allow admins to edit or delete projects from the Experience page
- show edit form, delete confirmation and notifications
- add corresponding styles for project actions and forms