### PR TITLE
Wrap certificate loader in useCallback

### DIFF
--- a/frontend/src/context/CertificatesContext.js
+++ b/frontend/src/context/CertificatesContext.js
@@ -1,4 +1,4 @@
-import { createContext, useContext, useReducer, useEffect } from 'react';
+import { createContext, useContext, useReducer, useCallback } from 'react';
 import {
   fetchCertificates,
   createCertificate,
@@ -44,7 +44,7 @@ function certificatesReducer(state, action) {
 export const CertificatesProvider = ({ children }) => {
   const [state, dispatch] = useReducer(certificatesReducer, initialState);
 
-  const loadCertificates = async () => {
+  const loadCertificates = useCallback(async () => {
     dispatch({ type: 'FETCH_START' });
     try {
       const data = await fetchCertificates();
@@ -52,7 +52,7 @@ export const CertificatesProvider = ({ children }) => {
     } catch (err) {
       dispatch({ type: 'FETCH_FAILURE', payload: err.message });
     }
-  };
+  }, []);
 
   const addCertificate = async (certificate) => {
     try {


### PR DESCRIPTION
## Summary
- memoize the certificate loader with `useCallback`
- expose the callback through context