### PR TITLE
Wrap end date inputs in form row

### DIFF
--- a/frontend/src/components/dashboard/DashboardExperiences.js
+++ b/frontend/src/components/dashboard/DashboardExperiences.js
@@ -226,43 +226,45 @@ const DashboardExperiences = () => {
                 onChange={handleChange}
               />
             </div>
-            <div className="form-group">
-              <label htmlFor="currentlyWorking">
-                <input
-                  id="currentlyWorking"
-                  name="currentlyWorking"
-                  type="checkbox"
-                  checked={formData.currentlyWorking}
+            <div className="end-date-row">
+              <div className="form-group checkbox-group">
+                <label htmlFor="currentlyWorking">
+                  <input
+                    id="currentlyWorking"
+                    name="currentlyWorking"
+                    type="checkbox"
+                    checked={formData.currentlyWorking}
+                    onChange={handleChange}
+                  />{' '}
+                  Currently Working
+                </label>
+              </div>
+              <div className="form-group">
+                <label htmlFor="endMonth">End Month</label>
+                <select
+                  id="endMonth"
+                  name="endMonth"
+                  value={formData.endMonth}
                   onChange={handleChange}
-                />{' '}
-                Currently Working
-              </label>
-            </div>
-            <div className="form-group">
-              <label htmlFor="endMonth">End Month</label>
-              <select
-                id="endMonth"
-                name="endMonth"
-                value={formData.endMonth}
-                onChange={handleChange}
-                disabled={formData.currentlyWorking}
-              >
-                <option value="">Month</option>
-                {[...Array(12).keys()].map((m) => (
-                  <option key={m + 1} value={m + 1}>{m + 1}</option>
-                ))}
-              </select>
-            </div>
-            <div className="form-group">
-              <label htmlFor="endYear">End Year</label>
-              <input
-                id="endYear"
-                name="endYear"
-                type="number"
-                value={formData.endYear}
-                onChange={handleChange}
-                disabled={formData.currentlyWorking}
-              />
+                  disabled={formData.currentlyWorking}
+                >
+                  <option value="">Month</option>
+                  {[...Array(12).keys()].map((m) => (
+                    <option key={m + 1} value={m + 1}>{m + 1}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="form-group">
+                <label htmlFor="endYear">End Year</label>
+                <input
+                  id="endYear"
+                  name="endYear"
+                  type="number"
+                  value={formData.endYear}
+                  onChange={handleChange}
+                  disabled={formData.currentlyWorking}
+                />
+              </div>
             </div>
             <div className="form-group" style={{ gridColumn: 'span 2' }}>
               <label htmlFor="skills">Skills (comma separated)</label>

--- a/frontend/src/pages/DashboardPage.css
+++ b/frontend/src/pages/DashboardPage.css
@@ -187,6 +187,13 @@
   font-weight: 500;
 }
 
+.end-date-row {
+  grid-column: span 2;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-6);
+}
+
 .char-count {
   font-size: var(--text-xs);
   color: var(--muted-foreground);

--- a/frontend/src/pages/Experience.css
+++ b/frontend/src/pages/Experience.css
@@ -309,6 +309,13 @@
   font-weight: 500;
 }
 
+.end-date-row {
+  grid-column: span 2;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-6);
+}
+
 .form-actions {
   grid-column: span 2;
   display: flex;

--- a/frontend/src/pages/Experience.js
+++ b/frontend/src/pages/Experience.js
@@ -386,43 +386,45 @@ const Experience = () => {
                       onChange={handleExpChange}
                     />
                   </div>
-                  <div className="form-group">
-                    <label htmlFor="currentlyWorking">
-                      <input
-                        id="currentlyWorking"
-                        name="currentlyWorking"
-                        type="checkbox"
-                        checked={expFormData.currentlyWorking}
+                  <div className="end-date-row">
+                    <div className="form-group checkbox-group">
+                      <label htmlFor="currentlyWorking">
+                        <input
+                          id="currentlyWorking"
+                          name="currentlyWorking"
+                          type="checkbox"
+                          checked={expFormData.currentlyWorking}
+                          onChange={handleExpChange}
+                        />{' '}
+                        Currently Working
+                      </label>
+                    </div>
+                    <div className="form-group">
+                      <label htmlFor="endMonth">End Month</label>
+                      <select
+                        id="endMonth"
+                        name="endMonth"
+                        value={expFormData.endMonth}
                         onChange={handleExpChange}
-                      />{' '}
-                      Currently Working
-                    </label>
-                  </div>
-                  <div className="form-group">
-                    <label htmlFor="endMonth">End Month</label>
-                    <select
-                      id="endMonth"
-                      name="endMonth"
-                      value={expFormData.endMonth}
-                      onChange={handleExpChange}
-                      disabled={expFormData.currentlyWorking}
-                    >
-                      <option value="">Month</option>
-                      {[...Array(12).keys()].map((m) => (
-                        <option key={m + 1} value={m + 1}>{m + 1}</option>
-                      ))}
-                    </select>
-                  </div>
-                  <div className="form-group">
-                    <label htmlFor="endYear">End Year</label>
-                    <input
-                      id="endYear"
-                      name="endYear"
-                      type="number"
-                      value={expFormData.endYear}
-                      onChange={handleExpChange}
-                      disabled={expFormData.currentlyWorking}
-                    />
+                        disabled={expFormData.currentlyWorking}
+                      >
+                        <option value="">Month</option>
+                        {[...Array(12).keys()].map((m) => (
+                          <option key={m + 1} value={m + 1}>{m + 1}</option>
+                        ))}
+                      </select>
+                    </div>
+                    <div className="form-group">
+                      <label htmlFor="endYear">End Year</label>
+                      <input
+                        id="endYear"
+                        name="endYear"
+                        type="number"
+                        value={expFormData.endYear}
+                        onChange={handleExpChange}
+                        disabled={expFormData.currentlyWorking}
+                      />
+                    </div>
                   </div>
                   <div className="form-group" style={{ gridColumn: 'span 2' }}>
                     <label htmlFor="skills">Skills (comma separated)</label>


### PR DESCRIPTION
## Summary
- group the 'currently working' checkbox and end date inputs
- add `.end-date-row` styles for both Dashboard and public experience forms