### PR TITLE
Implement lazy loading for dashboard data

### DIFF
--- a/frontend/src/context/ExperiencesContext.js
+++ b/frontend/src/context/ExperiencesContext.js
@@ -13,6 +13,7 @@ const initialState = {
   experiences: [],
   loading: false,
   error: null,
+  loaded: false,
 };
 
 function experiencesReducer(state, action) {
@@ -20,7 +21,7 @@ function experiencesReducer(state, action) {
     case 'FETCH_START':
       return { ...state, loading: true, error: null };
     case 'FETCH_SUCCESS':
-      return { ...state, loading: false, experiences: action.payload };
+      return { ...state, loading: false, experiences: action.payload, loaded: true };
     case 'FETCH_FAILURE':
       return { ...state, loading: false, error: action.payload };
     case 'ADD_SUCCESS':
@@ -46,6 +47,7 @@ export const ExperiencesProvider = ({ children }) => {
   const [state, dispatch] = useReducer(experiencesReducer, initialState);
 
   const loadExperiences = async () => {
+    if (state.loaded) return;
     dispatch({ type: 'FETCH_START' });
     try {
       const data = await fetchExperiences();

--- a/frontend/src/context/ProjectsContext.js
+++ b/frontend/src/context/ProjectsContext.js
@@ -15,6 +15,7 @@ const initialState = {
   projects: [],
   loading: false,
   error: null,
+  loaded: false,
 };
 
 function projectsReducer(state, action) {
@@ -22,7 +23,7 @@ function projectsReducer(state, action) {
     case 'FETCH_START':
       return { ...state, loading: true, error: null };
     case 'FETCH_SUCCESS':
-      return { ...state, loading: false, projects: action.payload };
+      return { ...state, loading: false, projects: action.payload, loaded: true };
     case 'FETCH_FAILURE':
       return { ...state, loading: false, error: action.payload };
     case 'ADD_SUCCESS':
@@ -48,6 +49,7 @@ export const ProjectsProvider = ({ children }) => {
   const [state, dispatch] = useReducer(projectsReducer, initialState);
 
   const loadProjects = async () => {
+    if (state.loaded) return;
     dispatch({ type: 'FETCH_START' });
     try {
       const data = await fetchProjects();

--- a/frontend/src/pages/Experience.js
+++ b/frontend/src/pages/Experience.js
@@ -49,6 +49,7 @@ const Experience = () => {
     addExperience,
     updateExperienceById,
     deleteExperienceById,
+    loaded: experiencesLoaded,
   } = useExperiences();
   const {
     projects,
@@ -60,6 +61,7 @@ const Experience = () => {
     loadProjects,
     uploadReport,
     fetchReport,
+    loaded: projectsLoaded,
   } = useProjects();
   const { user } = useAuth();
   const isAdmin = user?.role === 'admin';
@@ -78,8 +80,18 @@ const Experience = () => {
   /* start animations after first paint */
   useEffect(() => {
     requestAnimationFrame(() => setAnimate(true));
-    loadExperiences();
-    loadProjects();
+  }, []);
+
+  useEffect(() => {
+    if (activeTab === 'experience' && !experiencesLoaded) {
+      loadExperiences();
+    } else if (activeTab === 'projects' && !projectsLoaded) {
+      loadProjects();
+    }
+  }, [activeTab, experiencesLoaded, projectsLoaded, loadExperiences, loadProjects]);
+
+  useEffect(() => {
+    setCanEmbed(Boolean(navigator.mimeTypes?.['application/pdf']));
   }, []);
 
   useEffect(() => {

--- a/frontend/src/pages/ExperiencePage.test.js
+++ b/frontend/src/pages/ExperiencePage.test.js
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent, waitFor } from '../test-utils';
+import Experience from './Experience';
+import { ExperiencesProvider } from '../context/ExperiencesContext';
+import { ProjectsProvider } from '../context/ProjectsContext';
+
+const Wrapper = ({ children }) => (
+  <ExperiencesProvider>
+    <ProjectsProvider>{children}</ProjectsProvider>
+  </ExperiencesProvider>
+);
+
+const experiences = [{ id: 1, position: 'Dev', company: 'X' }];
+const projects = [{ id: 1, title: 'Proj', technologies: '' }];
+
+describe('Experience page lazy loading', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn((url) => {
+      if (url.includes('/experiences')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(experiences) });
+      }
+      if (url.includes('/projects')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(projects) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('APIs are called only once when switching tabs', async () => {
+    render(<Experience />, { wrapper: Wrapper });
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('button', { name: /projects/i }));
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByRole('button', { name: /professional experience/i }));
+    fireEvent.click(screen.getByRole('button', { name: /projects/i }));
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add loaded flag in ExperiencesContext
- add loaded flag in ProjectsContext
- lazy-load data in Experience page and detect PDF support
- regression test ensuring data loads once
- remove previous updates to deleted dashboard components