### PR TITLE
Fix checkbox group layout

### DIFF
--- a/frontend/src/pages/Experience.css
+++ b/frontend/src/pages/Experience.css
@@ -309,6 +309,12 @@
   font-weight: 500;
 }
 
+/* Align checkbox labels and inputs horizontally */
+.checkbox-group {
+  display: flex;
+  align-items: center;
+}
+
 .end-date-row {
   grid-column: span 2;
   display: grid;

--- a/frontend/src/pages/Experience.js
+++ b/frontend/src/pages/Experience.js
@@ -435,9 +435,6 @@ const Experience = () => {
                       />
                     </div>
                   <div className="form-group checkbox-group">
-                      <label htmlFor="currentlyWorking">
-                        Currently Working
-                      </label>
                       <input
                           id="currentlyWorking"
                           name="currentlyWorking"
@@ -445,6 +442,9 @@ const Experience = () => {
                           checked={expFormData.currentlyWorking}
                           onChange={handleExpChange}
                         />
+                      <label htmlFor="currentlyWorking">
+                        Currently Working
+                      </label>
                     </div>
                   <div className="form-group" style={{ gridColumn: 'span 2' }}>
                     <label htmlFor="skills">Skills (comma separated)</label>


### PR DESCRIPTION
## Summary
- align checkboxes in the Experience form with flexbox
- reorder markup so the checkbox and label sit side by side

## Testing
- `npm test` *(fails: 403 Forbidden when installing packages)*

------
https://chatgpt.com/codex/tasks/task_e_687575eb8b3883229d08dbc184bd9bfe