### PR TITLE
Wrap end date row

### DIFF
--- a/frontend/src/pages/Experience.js
+++ b/frontend/src/pages/Experience.js
@@ -408,6 +408,7 @@ const Experience = () => {
                       onChange={handleExpChange}
                     />
                   </div>
+                  <div className="end-date-row">
                     <div className="form-group">
                       <label htmlFor="endMonth">End Month</label>
                       <select
@@ -434,18 +435,19 @@ const Experience = () => {
                         disabled={expFormData.currentlyWorking}
                       />
                     </div>
-                  <div className="form-group checkbox-group">
+                    <div className="form-group checkbox-group">
                       <input
-                          id="currentlyWorking"
-                          name="currentlyWorking"
-                          type="checkbox"
-                          checked={expFormData.currentlyWorking}
-                          onChange={handleExpChange}
-                        />
+                        id="currentlyWorking"
+                        name="currentlyWorking"
+                        type="checkbox"
+                        checked={expFormData.currentlyWorking}
+                        onChange={handleExpChange}
+                      />
                       <label htmlFor="currentlyWorking">
                         Currently Working
                       </label>
                     </div>
+                  </div>
                   <div className="form-group" style={{ gridColumn: 'span 2' }}>
                     <label htmlFor="skills">Skills (comma separated)</label>
                     <input


### PR DESCRIPTION
## Summary
- align end date fields by grouping them in `.end-date-row`

## Testing
- `npm --prefix frontend test` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_687576e0e2048322a5bacf364a12ca10