### PR TITLE
Use month names for start/end selectors

### DIFF
--- a/frontend/src/pages/Experience.js
+++ b/frontend/src/pages/Experience.js
@@ -7,6 +7,21 @@ import { useAuth } from '../context/AuthContext';
 import './Experience.css';
 import Card from '../components/shared/Card';
 
+const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
 const Experience = () => {
   const [activeTab, setActiveTab] = useState('experience');
   const [selectedProject, setSelectedProject] = useState(null);
@@ -393,8 +408,8 @@ const Experience = () => {
                       onChange={handleExpChange}
                     >
                       <option value="">Month</option>
-                      {[...Array(12).keys()].map((m) => (
-                        <option key={m + 1} value={m + 1}>{m + 1}</option>
+                      {MONTH_NAMES.map((name, i) => (
+                        <option key={i + 1} value={i + 1}>{name}</option>
                       ))}
                     </select>
                   </div>
@@ -419,8 +434,8 @@ const Experience = () => {
                         disabled={expFormData.currentlyWorking}
                       >
                         <option value="">Month</option>
-                        {[...Array(12).keys()].map((m) => (
-                          <option key={m + 1} value={m + 1}>{m + 1}</option>
+                        {MONTH_NAMES.map((name, i) => (
+                          <option key={i + 1} value={i + 1}>{name}</option>
                         ))}
                       </select>
                     </div>


### PR DESCRIPTION
## Summary
- add `MONTH_NAMES` array in Experience.js
- map over month names for start month and end month selects

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `CI=true npm test` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68757a3d67e083229438b800b99fff24