### PR TITLE
Create reusable modal component

### DIFF
--- a/frontend/src/components/Certificates.js
+++ b/frontend/src/components/Certificates.js
@@ -3,6 +3,7 @@ import { useAuth } from '../context/AuthContext';
 import { useCertificates } from '../context/CertificatesContext';
 import '../pages/CertificationsPage.css';
 import Card from './shared/Card';
+import Modal from './shared/Modal';
 
 const Certificates = () => {
   const { user } = useAuth();
@@ -508,69 +509,66 @@ const Certificates = () => {
             )}
           </div>
         )}
-        {selectedCertificate && (
-          <div className="certificate-modal" onClick={() => setSelectedCertificate(null)}>
-            <div className="certificate-modal-content" onClick={(e) => e.stopPropagation()}>
-              <button className="close-button" onClick={() => setSelectedCertificate(null)}>
-                ×
-              </button>
-
-              <div
-                className="certificate-modal-image"
-                style={selectedCertificate.imageUrl ? { backgroundImage: `url(${selectedCertificate.imageUrl})` } : {}}
-              >
-                {!selectedCertificate.imageUrl && (
-                  <div className="certificate-placeholder large">
-                    <span>No Image Available</span>
-                  </div>
-                )}
+        <Modal
+          isOpen={Boolean(selectedCertificate)}
+          onClose={() => setSelectedCertificate(null)}
+          title={selectedCertificate?.title}
+          contentClassName="certificate-modal-content"
+        >
+          <div
+            className="certificate-modal-image"
+            style={selectedCertificate?.imageUrl ? { backgroundImage: `url(${selectedCertificate.imageUrl})` } : {}}
+          >
+            {!selectedCertificate?.imageUrl && (
+              <div className="certificate-placeholder large">
+                <span>No Image Available</span>
               </div>
-
-              <div className="certificate-modal-details">
-                <h2>{selectedCertificate.title}</h2>
-                <p className="certificate-issuer">Issued by {selectedCertificate.issuer}</p>
-                <p className="certificate-date">
-                  Date:{' '}
-                  {new Date(selectedCertificate.date).toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  })}
-                </p>
-
-                <div className="certificate-takeaway-section">
-                  <h3>What I Learned</h3>
-                  <p>{selectedCertificate.takeaway || 'No summary available.'}</p>
-                </div>
-
-                {selectedCertificate.children && selectedCertificate.children.length > 0 && (
-                  <div className="course-certifications">
-                    <h3>Course Certifications</h3>
-                    <p>
-                      Here are the individual courses completed within the {selectedCertificate.title} Professional
-                      Certificate program, along with their respective certificates:
-                    </p>
-                    <div className="course-cert-list">
-                      {selectedCertificate.children.map((child) => (
-                        <div className="course-card" key={child.id}>
-                          <h4>{child.title}</h4>
-                          <p>{child.takeaway}</p>
-                          {child.status === 'In Progress' ? (
-                            <p className="status ongoing">Status: {child.status}</p>
-                          ) : (
-                            <a href={child.certificateLink} target="_blank" rel="noopener noreferrer">
-                              View Certificate
-                            </a>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
+            )}
           </div>
-        )}
+
+          <div className="certificate-modal-details">
+            <p className="certificate-issuer">Issued by {selectedCertificate?.issuer}</p>
+            <p className="certificate-date">
+              Date{' '}
+              {selectedCertificate &&
+                new Date(selectedCertificate.date).toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+            </p>
+
+            <div className="certificate-takeaway-section">
+              <h3>What I Learned</h3>
+              <p>{selectedCertificate?.takeaway || 'No summary available.'}</p>
+            </div>
+
+            {selectedCertificate?.children && selectedCertificate.children.length > 0 && (
+              <div className="course-certifications">
+                <h3>Course Certifications</h3>
+                <p>
+                  Here are the individual courses completed within the {selectedCertificate.title} Professional
+                  Certificate program, along with their respective certificates:
+                </p>
+                <div className="course-cert-list">
+                  {selectedCertificate.children.map((child) => (
+                    <div className="course-card" key={child.id}>
+                      <h4>{child.title}</h4>
+                      <p>{child.takeaway}</p>
+                      {child.status === 'In Progress' ? (
+                        <p className="status ongoing">Status: {child.status}</p>
+                      ) : (
+                        <a href={child.certificateLink} target="_blank" rel="noopener noreferrer">
+                          View Certificate
+                        </a>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </Modal>
       </div>
     );
   }
@@ -648,69 +646,66 @@ const Certificates = () => {
           )}
         </div>
 
-        {selectedCertificate && (
-          <div className="certificate-modal" onClick={() => setSelectedCertificate(null)}>
-            <div className="certificate-modal-content" onClick={(e) => e.stopPropagation()}>
-              <button className="close-button" onClick={() => setSelectedCertificate(null)}>
-                ×
-              </button>
-
-              <div
-                className="certificate-modal-image"
-                style={selectedCertificate.imageUrl ? { backgroundImage: `url(${selectedCertificate.imageUrl})` } : {}}
-              >
-                {!selectedCertificate.imageUrl && (
-                  <div className="certificate-placeholder large">
-                    <span>No Image Available</span>
-                  </div>
-                )}
+        <Modal
+          isOpen={Boolean(selectedCertificate)}
+          onClose={() => setSelectedCertificate(null)}
+          title={selectedCertificate?.title}
+          contentClassName="certificate-modal-content"
+        >
+          <div
+            className="certificate-modal-image"
+            style={selectedCertificate?.imageUrl ? { backgroundImage: `url(${selectedCertificate.imageUrl})` } : {}}
+          >
+            {!selectedCertificate?.imageUrl && (
+              <div className="certificate-placeholder large">
+                <span>No Image Available</span>
               </div>
-
-              <div className="certificate-modal-details">
-                <h2>{selectedCertificate.title}</h2>
-                <p className="certificate-issuer">Issued by {selectedCertificate.issuer}</p>
-                <p className="certificate-date">
-                  Date:{' '}
-                  {new Date(selectedCertificate.date).toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  })}
-                </p>
-
-                <div className="certificate-takeaway-section">
-                  <h3>What I Learned</h3>
-                  <p>{selectedCertificate.takeaway || 'No summary available.'}</p>
-                </div>
-
-                {selectedCertificate.children && selectedCertificate.children.length > 0 && (
-                  <div className="course-certifications">
-                    <h3>Course Certifications</h3>
-                    <p>
-                      Here are the individual courses completed within the {selectedCertificate.title} Professional
-                      Certificate program, along with their respective certificates:
-                    </p>
-                    <div className="course-cert-list">
-                      {selectedCertificate.children.map((child) => (
-                        <div className="course-card" key={child.id}>
-                          <h4>{child.title}</h4>
-                          <p>{child.takeaway}</p>
-                          {child.status === 'In Progress' ? (
-                            <p className="status ongoing">Status: {child.status}</p>
-                          ) : (
-                            <a href={child.certificateLink} target="_blank" rel="noopener noreferrer">
-                              View Certificate
-                            </a>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
+            )}
           </div>
-        )}
+
+          <div className="certificate-modal-details">
+            <p className="certificate-issuer">Issued by {selectedCertificate?.issuer}</p>
+            <p className="certificate-date">
+              Date{' '}
+              {selectedCertificate &&
+                new Date(selectedCertificate.date).toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+            </p>
+
+            <div className="certificate-takeaway-section">
+              <h3>What I Learned</h3>
+              <p>{selectedCertificate?.takeaway || 'No summary available.'}</p>
+            </div>
+
+            {selectedCertificate?.children && selectedCertificate.children.length > 0 && (
+              <div className="course-certifications">
+                <h3>Course Certifications</h3>
+                <p>
+                  Here are the individual courses completed within the {selectedCertificate.title} Professional
+                  Certificate program, along with their respective certificates:
+                </p>
+                <div className="course-cert-list">
+                  {selectedCertificate.children.map((child) => (
+                    <div className="course-card" key={child.id}>
+                      <h4>{child.title}</h4>
+                      <p>{child.takeaway}</p>
+                      {child.status === 'In Progress' ? (
+                        <p className="status ongoing">Status: {child.status}</p>
+                      ) : (
+                        <a href={child.certificateLink} target="_blank" rel="noopener noreferrer">
+                          View Certificate
+                        </a>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </Modal>
       </div>
     </div>
   );

--- a/frontend/src/components/shared/Modal.css
+++ b/frontend/src/components/shared/Modal.css
@@ -1,0 +1,61 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-50);
+  padding: var(--space-4);
+  animation: fadeIn var(--transition-fast);
+}
+
+.modal-content {
+  background-color: var(--background);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  max-width: 900px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+  animation: scaleIn var(--transition-normal);
+}
+
+.close-button {
+  position: absolute;
+  top: var(--space-4);
+  right: var(--space-4);
+  background-color: var(--muted);
+  border: none;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  font-size: var(--text-xl);
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 2;
+  transform: none;
+}
+
+.close-button:hover {
+  background-color: var(--muted-foreground);
+  color: var(--background);
+}
+
+@keyframes scaleIn {
+  from {
+    transform: scale(0.95);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}

--- a/frontend/src/components/shared/Modal.js
+++ b/frontend/src/components/shared/Modal.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import './Modal.css';
+
+const Modal = ({
+  isOpen,
+  onClose,
+  title,
+  children,
+  className = '',
+  contentClassName = '',
+  closeButtonClassName = '',
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className={`modal-overlay ${className}`.trim()} onClick={onClose}>
+      <div
+        className={`modal-content ${contentClassName}`.trim()}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          className={`close-button ${closeButtonClassName}`.trim()}
+          onClick={onClose}
+          aria-label="Close modal"
+        >
+          &times;
+        </button>
+        {title && <h2>{title}</h2>}
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/frontend/src/pages/CertificationsPage.css
+++ b/frontend/src/pages/CertificationsPage.css
@@ -130,56 +130,6 @@
   color: var(--muted-foreground);
 }
 
-.certificate-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.75);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-50);
-  padding: var(--space-4);
-  animation: fadeIn var(--transition-fast);
-}
-
-.certificate-modal-content {
-  background-color: var(--background);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-xl);
-  max-width: 900px;
-  width: 90%;
-  max-height: 90vh;
-  overflow-y: auto;
-  position: relative;
-  animation: scaleIn var(--transition-normal);
-}
-
-.close-button {
-  position: absolute;
-  top: var(--space-4);
-  right: var(--space-4);
-  background-color: var(--muted);
-  border: none;
-  width: 32px;
-  height: 32px;
-  border-radius: var(--radius-full);
-  font-size: var(--text-xl);
-  line-height: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  z-index: 2;
-  transform: none;
-}
-
-.close-button:hover {
-  background-color: var(--muted-foreground);
-  color: var(--background);
-}
 
 .certificate-modal-image {
   width: 100%;
@@ -214,25 +164,6 @@
   color: var(--primary);
 }
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes scaleIn {
-  from {
-    transform: scale(0.95);
-    opacity: 0;
-  }
-  to {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
 
 @media (max-width: 768px) {
   .certifications-header h1 {

--- a/frontend/src/pages/Experience.css
+++ b/frontend/src/pages/Experience.css
@@ -427,56 +427,6 @@
 }
 
 /* Project Modal */
-.project-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.75);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-50);
-  padding: var(--space-4);
-  animation: fadeIn var(--transition-fast);
-}
-
-.project-modal-content {
-  background-color: var(--background);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-xl);
-  max-width: 900px;
-  width: 90%;
-  max-height: 90vh;
-  overflow-y: auto;
-  position: relative;
-  animation: scaleIn var(--transition-normal);
-}
-
-.close-button {
-  position: absolute;
-  top: var(--space-4);
-  right: var(--space-4);
-  background-color: var(--muted);
-  border: none;
-  width: 32px;
-  height: 32px;
-  border-radius: var(--radius-full);
-  font-size: var(--text-xl);
-  line-height: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  z-index: 2;
-  transform: none;
-}
-
-.close-button:hover {
-  background-color: var(--muted-foreground);
-  color: var(--background);
-}
 
 .project-modal-image {
   width: 100%;
@@ -533,25 +483,6 @@
   margin-top: 1.5rem;
 }
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes scaleIn {
-  from {
-    transform: scale(0.95);
-    opacity: 0;
-  }
-  to {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
 
 @media (max-width: 768px) {
   .experience-timeline::before {
@@ -606,62 +537,6 @@
   to { opacity: 1; transform: scale(1); }
 }
 
-.experience-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.75);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-50);
-  padding: var(--space-4);
-  animation: fadeIn var(--transition-fast);
-}
-
-.experience-modal-content {
-  background-color: var(--background);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-xl);
-  max-width: 900px;
-  width: 90%;
-  max-height: 90vh;
-  overflow-y: auto;
-  position: relative;
-  /* extra space for the sticky close button */
-  /* padding-top: var(--space-16); */
-  animation: scaleIn var(--transition-normal);
-}
-
-.project-form-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.75);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-50);
-  padding: var(--space-4);
-  animation: fadeIn var(--transition-fast);
-}
-
-.project-form-modal-content {
-  background-color: var(--background);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-xl);
-  max-width: 900px;
-  width: 90%;
-  max-height: 90vh;
-  overflow-y: auto;
-  position: relative;
-  /* padding-top: var(--space-16); */
-  animation: scaleIn var(--transition-normal);
-}
 
 .dashboard-header {
   display: flex;

--- a/frontend/src/pages/Experience.js
+++ b/frontend/src/pages/Experience.js
@@ -7,6 +7,7 @@ import { useProjects } from '../context/ProjectsContext';
 import { useAuth } from '../context/AuthContext';
 import './Experience.css';
 import Card from '../components/shared/Card';
+import Modal from '../components/shared/Modal';
 
 const Experience = () => {
   const [activeTab, setActiveTab] = useState('experience');
@@ -420,24 +421,14 @@ const Experience = () => {
       </div>
             )}
             {isAdmin && isExpAdding && (
-              <div
-                className="experience-modal"
-                onClick={() => { setIsExpAdding(false); setExpEditingId(null); setExpErrors({}); }}
+              <Modal
+                isOpen={isExpAdding}
+                onClose={() => { setIsExpAdding(false); setExpEditingId(null); setExpErrors({}); }}
+                title={expEditingId ? 'Edit Experience' : 'Add New Experience'}
+                contentClassName="experience-modal-content"
               >
-                <div
-                  className="experience-modal-content"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <button
-                    type="button"
-                    className="close-button"
-                    onClick={() => { setIsExpAdding(false); setExpEditingId(null); setExpErrors({}); }}
-                  >
-                    ×
-                  </button>
-                  <div className="certificate-form-container">
-                    <h2>{expEditingId ? 'Edit Experience' : 'Add New Experience'}</h2>
-                    <form className="certificate-form" onSubmit={handleExpSubmit}>
+                <div className="certificate-form-container">
+                  <form className="certificate-form" onSubmit={handleExpSubmit}>
                   <div className="form-group">
                     <label htmlFor="position">Position*</label>
                     <input
@@ -573,8 +564,7 @@ const Experience = () => {
                   </div>
                 </form>
                   </div>
-                </div>
-              </div>
+              </Modal>
             )}
             {experiences.length === 0 ? (
               <div className="empty-state">
@@ -682,32 +672,18 @@ const Experience = () => {
               </button>
             )}
             {isAdmin && (isAdding || isEditing) && (
-              <div
-                className="project-form-modal"
-                onClick={() => {
+              <Modal
+                isOpen={isAdding || isEditing}
+                onClose={() => {
                   setIsAdding(false);
                   setIsEditing(false);
                   setEditingId(null);
                 }}
+                title={isEditing ? 'Edit Project' : 'Add New Project'}
+                contentClassName="project-form-modal-content"
               >
-                <div
-                  className="project-form-modal-content"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <button
-                    type="button"
-                    className="close-button"
-                    onClick={() => {
-                      setIsAdding(false);
-                      setIsEditing(false);
-                      setEditingId(null);
-                    }}
-                  >
-                    ×
-                  </button>
-                  <div className="certificate-form-container">
-                    <h2>{isEditing ? 'Edit Project' : 'Add New Project'}</h2>
-                    <form className="certificate-form" onSubmit={handleSubmit}>
+                <div className="certificate-form-container">
+                  <form className="certificate-form" onSubmit={handleSubmit}>
                   <div className="form-group">
                     <label htmlFor="title">Title*</label>
                     <input
@@ -785,8 +761,7 @@ const Experience = () => {
                   </div>
                 </form>
               </div>
-            </div>
-          </div>
+              </Modal>
             )}
             <div className="projects-grid">
               {projects.length === 0 ? (
@@ -845,30 +820,20 @@ const Experience = () => {
 
         {/* ───────── modal ───────── */}
         {selectedProject && (
-          <div
-            className="project-modal"
-            onClick={() => setSelectedProject(null)}
+          <Modal
+            isOpen={Boolean(selectedProject)}
+            onClose={() => setSelectedProject(null)}
+            contentClassName="project-modal-content fade-in-up run"
+            title={selectedProject.title}
           >
-            <div
-              className="project-modal-content fade-in-up run"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <button
-                className="close-button"
-                onClick={() => setSelectedProject(null)}
-              >
-                ×
-              </button>
+            <img
+              className="project-modal-image"
+              src={selectedProject.imageUrl}
+              alt={selectedProject.title}
+            />
 
-              <img
-                className="project-modal-image"
-                src={selectedProject.imageUrl}
-                alt={selectedProject.title}
-              />
-
-              <div className="project-modal-details">
-                <h2>{selectedProject.title}</h2>
-                <p>{selectedProject.description}</p>
+            <div className="project-modal-details">
+              <p>{selectedProject.description}</p>
 
                 <h3>Technologies Used</h3>
                 <div className="technologies">
@@ -908,8 +873,7 @@ const Experience = () => {
                   </div>
                 )}
               </div>
-            </div>
-          </div>
+            </Modal>
         )}
       </div>
     </div>

--- a/frontend/src/pages/LeetCodePage.css
+++ b/frontend/src/pages/LeetCodePage.css
@@ -118,59 +118,6 @@
   overflow: auto;
 }
 
-.problem-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.75);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-50);
-  padding: var(--space-4);
-  animation: fadeIn var(--transition-fast);
-}
-
-.problem-modal-content {
-  background-color: var(--background);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-xl);
-  max-width: 900px;
-  width: 90%;
-  max-height: 90vh;
-  overflow-y: auto;
-  position: relative;
-  /* extra space for the sticky close button */
-  padding-top: var(--space-16);
-  animation: scaleIn var(--transition-normal);
-}
-
-.close-button {
-  position: sticky;
-  top: var(--space-4);
-  right: var(--space-4);
-  margin-left: auto;
-  background-color: var(--muted);
-  border: none;
-  width: 32px;
-  height: 32px;
-  border-radius: var(--radius-full);
-  font-size: var(--text-xl);
-  line-height: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  z-index: 2;
-  transform: none;
-}
-
-.close-button:hover {
-  background-color: var(--muted-foreground);
-  color: var(--background);
-}
 
 .problem-modal-content h2 {
   text-align: center;
@@ -194,25 +141,6 @@
   text-decoration: underline;
 }
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes scaleIn {
-  from {
-    transform: scale(0.95);
-    opacity: 0;
-  }
-  to {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
 
 @media (max-width: 768px) {
   .problem-modal-content {

--- a/frontend/src/pages/LeetCodePage.js
+++ b/frontend/src/pages/LeetCodePage.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import './LeetCodePage.css';
 import defaultProblems from '../data/leetcodeProblems';
 import ProgressCircle from '../components/leetcode/ProgressCircle';
+import Modal from '../components/shared/Modal';
 import {
   fetchLeetcodeProblems,
   createLeetcodeProblem,
@@ -30,10 +31,7 @@ const ProblemModal = ({ problem, onClose, onEdit }) => {
   }, [problem]);
 
   return (
-    <div className="problem-modal" onClick={onClose}>
-      <div className="problem-modal-content" onClick={(e) => e.stopPropagation()}>
-        <button className="close-button" onClick={onClose}>×</button>
-        <h2>{problem.title}</h2>
+    <Modal isOpen={Boolean(problem)} onClose={onClose} contentClassName="problem-modal-content" title={problem.title}>
         <p className={`difficulty ${problem.difficulty.toLowerCase()}`}>{problem.difficulty}</p>
 
         {problem.statement && <p className="statement">{problem.statement}</p>}
@@ -84,8 +82,7 @@ const ProblemModal = ({ problem, onClose, onEdit }) => {
             )}
           </div>
         )}
-      </div>
-    </div>
+    </Modal>
   );
 };
 
@@ -440,19 +437,13 @@ const LeetCodePage = () => {
       )}
 
         {isAdmin && isFormOpen && (
-          <div className="problem-modal" onClick={() => setIsFormOpen(false)}>
-            <div
-              className="problem-modal-content"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <button
-                className="close-button"
-                onClick={() => setIsFormOpen(false)}
-              >
-                ×
-              </button>
-              <h2>{editingId ? 'Edit Problem' : 'Add New Problem'}</h2>
-              <form className="leetcode-form" onSubmit={handleSubmit}>
+          <Modal
+            isOpen={isFormOpen}
+            onClose={() => setIsFormOpen(false)}
+            title={editingId ? 'Edit Problem' : 'Add New Problem'}
+            contentClassName="problem-modal-content"
+          >
+            <form className="leetcode-form" onSubmit={handleSubmit}>
                 {formMessage && (
                   <div className="form-message">{formMessage}</div>
                 )}
@@ -553,8 +544,7 @@ const LeetCodePage = () => {
                   {editingId ? 'Save Changes' : 'Add New Problem'}
                 </button>
               </form>
-            </div>
-          </div>
+            </Modal>
         )}
 
         {selectedProblem && (


### PR DESCRIPTION
## Summary
- add shared `Modal` component
- refactor Certificates, Experience, and LeetCode pages to use `<Modal>`
- remove old modal CSS in page styles

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test --silent` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877f30cc01083228432ee52151e3760