### PR TITLE
Add analytics tracking service

### DIFF
--- a/backend-java/src/main/java/com/example/demo/controller/AnalyticsController.java
+++ b/backend-java/src/main/java/com/example/demo/controller/AnalyticsController.java
@@ -1,0 +1,29 @@
+package com.example.demo.controller;
+
+import com.example.demo.service.AnalyticsService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+
+@RestController
+@RequestMapping("/api/analytics")
+public class AnalyticsController {
+
+    private final AnalyticsService analyticsService;
+
+    public AnalyticsController(AnalyticsService analyticsService) {
+        this.analyticsService = analyticsService;
+    }
+
+    @GetMapping("")
+    public ResponseEntity<?> getAnalytics(@RequestParam(required = false) String start,
+                                          @RequestParam(required = false) String end) {
+        Instant startInstant = start != null ? Instant.parse(start) : null;
+        Instant endInstant = end != null ? Instant.parse(end) : null;
+        return ResponseEntity.ok(analyticsService.getCounts(startInstant, endInstant));
+    }
+}

--- a/backend-java/src/main/java/com/example/demo/controller/DocumentController.java
+++ b/backend-java/src/main/java/com/example/demo/controller/DocumentController.java
@@ -2,6 +2,7 @@ package com.example.demo.controller;
 
 import com.example.demo.model.DocumentEntity;
 import com.example.demo.repository.DocumentRepository;
+import com.example.demo.service.AnalyticsService;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -19,10 +20,12 @@ import java.util.Map;
 public class DocumentController {
 
     private final DocumentRepository documentRepository;
+    private final AnalyticsService analyticsService;
     private final Path uploadDir = Paths.get("uploads");
 
-    public DocumentController(DocumentRepository documentRepository) throws IOException {
+    public DocumentController(DocumentRepository documentRepository, AnalyticsService analyticsService) throws IOException {
         this.documentRepository = documentRepository;
+        this.analyticsService = analyticsService;
         Files.createDirectories(uploadDir);
     }
 
@@ -78,6 +81,11 @@ public class DocumentController {
             contentType = Files.probeContentType(filePath);
         } catch (IOException e) {
             contentType = MediaType.APPLICATION_OCTET_STREAM_VALUE;
+        }
+        if ("resume".equalsIgnoreCase(type)) {
+            analyticsService.recordEvent(AnalyticsService.EVENT_CV_DOWNLOAD);
+        } else {
+            analyticsService.recordEvent(AnalyticsService.EVENT_COVERLETTER_DOWNLOAD);
         }
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + entity.getFileName())

--- a/backend-java/src/main/java/com/example/demo/controller/SignupController.java
+++ b/backend-java/src/main/java/com/example/demo/controller/SignupController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.demo.model.UserEntity;
 import com.example.demo.repository.UserRepository;
 import com.example.demo.service.EncryptionService;
+import com.example.demo.service.AnalyticsService;
 
 @RestController
 public class SignupController {
@@ -21,10 +22,12 @@ public class SignupController {
 
     private final UserRepository userRepository;
     private final EncryptionService encryptionService;
+    private final AnalyticsService analyticsService;
 
-    public SignupController(UserRepository userRepository, EncryptionService encryptionService) {
+    public SignupController(UserRepository userRepository, EncryptionService encryptionService, AnalyticsService analyticsService) {
         this.userRepository = userRepository;
         this.encryptionService = encryptionService;
+        this.analyticsService = analyticsService;
     }
 
     @PostMapping("/api/signup")
@@ -45,6 +48,7 @@ public class SignupController {
         entity.setLastLoggedInDate(Instant.now());
         entity.setAdmin(false);
         userRepository.save(entity);
+        analyticsService.recordEvent(AnalyticsService.EVENT_USER_SIGNUP);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(Map.of("message", "Welcome, " + request.fullName() + "!"));
     }

--- a/backend-java/src/main/java/com/example/demo/model/AnalyticsEventEntity.java
+++ b/backend-java/src/main/java/com/example/demo/model/AnalyticsEventEntity.java
@@ -1,0 +1,42 @@
+package com.example.demo.model;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "analytics_events")
+public class AnalyticsEventEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String eventType;
+
+    @Column(nullable = false)
+    private Instant timestamp;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/backend-java/src/main/java/com/example/demo/repository/AnalyticsEventRepository.java
+++ b/backend-java/src/main/java/com/example/demo/repository/AnalyticsEventRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.AnalyticsEventEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.Instant;
+
+public interface AnalyticsEventRepository extends JpaRepository<AnalyticsEventEntity, Long> {
+    long countByEventType(String eventType);
+    long countByEventTypeAndTimestampBetween(String eventType, Instant start, Instant end);
+}

--- a/backend-java/src/main/java/com/example/demo/service/AnalyticsService.java
+++ b/backend-java/src/main/java/com/example/demo/service/AnalyticsService.java
@@ -1,0 +1,53 @@
+package com.example.demo.service;
+
+import com.example.demo.model.AnalyticsEventEntity;
+import com.example.demo.repository.AnalyticsEventRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class AnalyticsService {
+
+    public static final String EVENT_GUEST_LOGIN = "GUEST_LOGIN";
+    public static final String EVENT_USER_SIGNUP = "USER_SIGNUP";
+    public static final String EVENT_CV_DOWNLOAD = "CV_DOWNLOAD";
+    public static final String EVENT_COVERLETTER_DOWNLOAD = "COVERLETTER_DOWNLOAD";
+
+    private final AnalyticsEventRepository repository;
+
+    public AnalyticsService(AnalyticsEventRepository repository) {
+        this.repository = repository;
+    }
+
+    public void recordEvent(String type) {
+        AnalyticsEventEntity entity = new AnalyticsEventEntity();
+        entity.setEventType(type);
+        entity.setTimestamp(Instant.now());
+        repository.save(entity);
+    }
+
+    public long countEvents(String type, Instant start, Instant end) {
+        if (start == null && end == null) {
+            return repository.countByEventType(type);
+        }
+        if (start == null) {
+            start = Instant.EPOCH;
+        }
+        if (end == null) {
+            end = Instant.now();
+        }
+        return repository.countByEventTypeAndTimestampBetween(type, start, end);
+    }
+
+    public Map<String, Long> getCounts(Instant start, Instant end) {
+        Map<String, Long> result = new HashMap<>();
+        result.put(EVENT_GUEST_LOGIN, countEvents(EVENT_GUEST_LOGIN, start, end));
+        result.put(EVENT_USER_SIGNUP, countEvents(EVENT_USER_SIGNUP, start, end));
+        result.put(EVENT_CV_DOWNLOAD, countEvents(EVENT_CV_DOWNLOAD, start, end));
+        result.put(EVENT_COVERLETTER_DOWNLOAD, countEvents(EVENT_COVERLETTER_DOWNLOAD, start, end));
+        return result;
+    }
+}

--- a/backend-java/src/test/java/com/example/demo/controller/DocumentControllerTest.java
+++ b/backend-java/src/test/java/com/example/demo/controller/DocumentControllerTest.java
@@ -2,6 +2,7 @@ package com.example.demo.controller;
 
 import com.example.demo.model.DocumentEntity;
 import com.example.demo.repository.DocumentRepository;
+import com.example.demo.service.AnalyticsService;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +32,9 @@ class DocumentControllerTest {
 
     @MockBean
     private DocumentRepository documentRepository;
+
+    @MockBean
+    private AnalyticsService analyticsService;
 
     @Test
     void getAllDocumentsReturnsList() throws Exception {
@@ -95,6 +99,8 @@ class DocumentControllerTest {
                 .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION,
                         "attachment; filename=" + fileName))
                 .andExpect(content().string("content"));
+
+        verify(analyticsService).recordEvent(AnalyticsService.EVENT_CV_DOWNLOAD);
 
         Files.deleteIfExists(filePath);
     }

--- a/backend-java/src/test/java/com/example/demo/service/AnalyticsServiceTest.java
+++ b/backend-java/src/test/java/com/example/demo/service/AnalyticsServiceTest.java
@@ -1,0 +1,59 @@
+package com.example.demo.service;
+
+import com.example.demo.model.AnalyticsEventEntity;
+import com.example.demo.repository.AnalyticsEventRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AnalyticsServiceTest {
+
+    @Mock
+    private AnalyticsEventRepository repository;
+
+    @InjectMocks
+    private AnalyticsService analyticsService;
+
+    @Test
+    void recordEventStoresEntity() {
+        when(repository.save(any(AnalyticsEventEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        analyticsService.recordEvent(AnalyticsService.EVENT_GUEST_LOGIN);
+
+        ArgumentCaptor<AnalyticsEventEntity> captor = ArgumentCaptor.forClass(AnalyticsEventEntity.class);
+        verify(repository).save(captor.capture());
+        AnalyticsEventEntity saved = captor.getValue();
+        assertThat(saved.getEventType()).isEqualTo(AnalyticsService.EVENT_GUEST_LOGIN);
+        assertThat(saved.getTimestamp()).isNotNull();
+    }
+
+    @Test
+    void getCountsReturnsValues() {
+        Instant start = Instant.now().minusSeconds(3600);
+        Instant end = Instant.now();
+        when(repository.countByEventTypeAndTimestampBetween(eq(AnalyticsService.EVENT_GUEST_LOGIN), any(), any())).thenReturn(1L);
+        when(repository.countByEventTypeAndTimestampBetween(eq(AnalyticsService.EVENT_USER_SIGNUP), any(), any())).thenReturn(2L);
+        when(repository.countByEventTypeAndTimestampBetween(eq(AnalyticsService.EVENT_CV_DOWNLOAD), any(), any())).thenReturn(3L);
+        when(repository.countByEventTypeAndTimestampBetween(eq(AnalyticsService.EVENT_COVERLETTER_DOWNLOAD), any(), any())).thenReturn(4L);
+
+        Map<String, Long> counts = analyticsService.getCounts(start, end);
+
+        assertThat(counts).containsEntry(AnalyticsService.EVENT_GUEST_LOGIN, 1L)
+                .containsEntry(AnalyticsService.EVENT_USER_SIGNUP, 2L)
+                .containsEntry(AnalyticsService.EVENT_CV_DOWNLOAD, 3L)
+                .containsEntry(AnalyticsService.EVENT_COVERLETTER_DOWNLOAD, 4L);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `AnalyticsEventEntity` to persist analytic events
- create `AnalyticsEventRepository` for counting events
- add `AnalyticsService` and `AnalyticsController`
- record events from login, signup, and document download
- extend document tests and add analytics service tests