### PR TITLE
Implement analytics routes

### DIFF
--- a/backend-node/index.js
+++ b/backend-node/index.js
@@ -391,6 +391,36 @@ app.delete('/leetcode/:id', async (req, res) => {
   }
 });
 
-app.listen(PORT, () => {
-  console.log(`Node backend listening on port ${PORT}`);
+app.get('/analytics', async (req, res) => {
+  const { start, end } = req.query;
+  try {
+    const url = new URL(`${JAVA_BASE_URL}/api/analytics`);
+    if (start) url.searchParams.append('start', start);
+    if (end) url.searchParams.append('end', end);
+    const response = await fetch(url.toString());
+    const data = await parseJsonSafe(response);
+    res.status(response.status).json(data);
+  } catch (err) {
+    handleError(res, err);
+  }
 });
+
+app.post('/guest-login', async (req, res) => {
+  try {
+    const response = await fetch(`${JAVA_BASE_URL}/api/analytics/guest-login`, {
+      method: 'POST'
+    });
+    const data = await parseJsonSafe(response);
+    res.status(response.status).json(data);
+  } catch (err) {
+    handleError(res, err);
+  }
+});
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Node backend listening on port ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/backend-node/index.test.js
+++ b/backend-node/index.test.js
@@ -1,0 +1,25 @@
+const request = require('supertest');
+const fetchMock = require('node-fetch');
+
+jest.mock('node-fetch');
+
+describe('analytics route', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    process.env.JAVA_BASE_URL = 'http://java:8080';
+  });
+
+  it('forwards query params and returns json', async () => {
+    const mockResponse = {
+      status: 200,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify({ ok: true })
+    };
+    fetchMock.mockResolvedValue(mockResponse);
+    const app = require('./index');
+    await request(app)
+      .get('/analytics?start=123&end=456')
+      .expect(200, { ok: true });
+    expect(fetchMock).toHaveBeenCalledWith('http://java:8080/api/analytics?start=123&end=456');
+  });
+});

--- a/backend-node/package.json
+++ b/backend-node/package.json
@@ -4,12 +4,17 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.18.2",
     "cors": "^2.8.5",
     "node-fetch": "^3.3.2",
     "dotenv": "^10.0.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.4.2"
   }
 }


### PR DESCRIPTION
## Summary
- proxy analytics requests through node backend
- allow guest login analytics events to be sent
- export express app for testing
- add a basic Jest test for analytics proxy

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68781f5512388322a27658c9f18a8b99