### PR TITLE
Implement analytics tracking

### DIFF
--- a/backend-java/src/main/java/com/example/demo/controller/AnalyticsController.java
+++ b/backend-java/src/main/java/com/example/demo/controller/AnalyticsController.java
@@ -1,0 +1,35 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.AnalyticsEventEntity.EventType;
+import com.example.demo.service.AnalyticsService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/analytics")
+public class AnalyticsController {
+
+    private final AnalyticsService analyticsService;
+
+    public AnalyticsController(AnalyticsService analyticsService) {
+        this.analyticsService = analyticsService;
+    }
+
+    @GetMapping("")
+    public Map<String, Long> getAnalytics(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant start,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant end) {
+        return Map.of(
+                "guestLogins", analyticsService.countEvents(EventType.GUEST_LOGIN, start, end),
+                "signups", analyticsService.countEvents(EventType.USER_SIGNUP, start, end),
+                "cvDownloads", analyticsService.countEvents(EventType.CV_DOWNLOAD, start, end),
+                "coverletterDownloads", analyticsService.countEvents(EventType.COVERLETTER_DOWNLOAD, start, end)
+        );
+    }
+}

--- a/backend-java/src/main/java/com/example/demo/controller/DocumentController.java
+++ b/backend-java/src/main/java/com/example/demo/controller/DocumentController.java
@@ -2,6 +2,8 @@ package com.example.demo.controller;
 
 import com.example.demo.model.DocumentEntity;
 import com.example.demo.repository.DocumentRepository;
+import com.example.demo.service.AnalyticsService;
+import com.example.demo.model.AnalyticsEventEntity.EventType;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -19,10 +21,12 @@ import java.util.Map;
 public class DocumentController {
 
     private final DocumentRepository documentRepository;
+    private final AnalyticsService analyticsService;
     private final Path uploadDir = Paths.get("uploads");
 
-    public DocumentController(DocumentRepository documentRepository) throws IOException {
+    public DocumentController(DocumentRepository documentRepository, AnalyticsService analyticsService) throws IOException {
         this.documentRepository = documentRepository;
+        this.analyticsService = analyticsService;
         Files.createDirectories(uploadDir);
     }
 
@@ -78,6 +82,11 @@ public class DocumentController {
             contentType = Files.probeContentType(filePath);
         } catch (IOException e) {
             contentType = MediaType.APPLICATION_OCTET_STREAM_VALUE;
+        }
+        if ("resume".equalsIgnoreCase(type)) {
+            analyticsService.recordEvent(EventType.CV_DOWNLOAD);
+        } else {
+            analyticsService.recordEvent(EventType.COVERLETTER_DOWNLOAD);
         }
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + entity.getFileName())

--- a/backend-java/src/main/java/com/example/demo/controller/LoginController.java
+++ b/backend-java/src/main/java/com/example/demo/controller/LoginController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.demo.model.UserEntity;
 import com.example.demo.repository.UserRepository;
 import com.example.demo.service.EncryptionService;
+import com.example.demo.service.AnalyticsService;
+import com.example.demo.model.AnalyticsEventEntity.EventType;
 
 @RestController
 public class LoginController {
@@ -22,10 +24,12 @@ public class LoginController {
 
     private final UserRepository userRepository;
     private final EncryptionService encryptionService;
+    private final AnalyticsService analyticsService;
 
-    public LoginController(UserRepository userRepository, EncryptionService encryptionService) {
+    public LoginController(UserRepository userRepository, EncryptionService encryptionService, AnalyticsService analyticsService) {
         this.userRepository = userRepository;
         this.encryptionService = encryptionService;
+        this.analyticsService = analyticsService;
     }
 
     @PostMapping("/api/login")
@@ -42,6 +46,9 @@ public class LoginController {
         String decryptedPassword = encryptionService.decrypt(user.getPassword());
         if (!decryptedPassword.equals(request.password())) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "Invalid credentials"));
+        }
+        if ("guest@example.com".equals(request.email()) && "guest123".equals(request.password())) {
+            analyticsService.recordEvent(EventType.GUEST_LOGIN);
         }
         Instant previousLogin = user.getLastLoggedInDate();
         user.setLastLoggedInDate(Instant.now());

--- a/backend-java/src/main/java/com/example/demo/controller/SignupController.java
+++ b/backend-java/src/main/java/com/example/demo/controller/SignupController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.demo.model.UserEntity;
 import com.example.demo.repository.UserRepository;
 import com.example.demo.service.EncryptionService;
+import com.example.demo.service.AnalyticsService;
+import com.example.demo.model.AnalyticsEventEntity.EventType;
 
 @RestController
 public class SignupController {
@@ -21,10 +23,12 @@ public class SignupController {
 
     private final UserRepository userRepository;
     private final EncryptionService encryptionService;
+    private final AnalyticsService analyticsService;
 
-    public SignupController(UserRepository userRepository, EncryptionService encryptionService) {
+    public SignupController(UserRepository userRepository, EncryptionService encryptionService, AnalyticsService analyticsService) {
         this.userRepository = userRepository;
         this.encryptionService = encryptionService;
+        this.analyticsService = analyticsService;
     }
 
     @PostMapping("/api/signup")
@@ -45,6 +49,7 @@ public class SignupController {
         entity.setLastLoggedInDate(Instant.now());
         entity.setAdmin(false);
         userRepository.save(entity);
+        analyticsService.recordEvent(EventType.USER_SIGNUP);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(Map.of("message", "Welcome, " + request.fullName() + "!"));
     }

--- a/backend-java/src/main/java/com/example/demo/model/AnalyticsEventEntity.java
+++ b/backend-java/src/main/java/com/example/demo/model/AnalyticsEventEntity.java
@@ -1,0 +1,66 @@
+package com.example.demo.model;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "analytics_events")
+public class AnalyticsEventEntity {
+
+    public enum EventType {
+        GUEST_LOGIN,
+        USER_SIGNUP,
+        CV_DOWNLOAD,
+        COVERLETTER_DOWNLOAD
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EventType eventType;
+
+    @Column(nullable = false, updatable = false)
+    private Instant timestamp;
+
+    public AnalyticsEventEntity() {
+    }
+
+    public AnalyticsEventEntity(EventType eventType, Instant timestamp) {
+        this.eventType = eventType;
+        this.timestamp = timestamp;
+    }
+
+    @PrePersist
+    private void onCreate() {
+        if (timestamp == null) {
+            timestamp = Instant.now();
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public EventType getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(EventType eventType) {
+        this.eventType = eventType;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/backend-java/src/main/java/com/example/demo/repository/AnalyticsEventRepository.java
+++ b/backend-java/src/main/java/com/example/demo/repository/AnalyticsEventRepository.java
@@ -1,0 +1,12 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.AnalyticsEventEntity;
+import com.example.demo.model.AnalyticsEventEntity.EventType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.Instant;
+
+public interface AnalyticsEventRepository extends JpaRepository<AnalyticsEventEntity, Long> {
+    long countByEventTypeAndTimestampBetween(EventType eventType, Instant start, Instant end);
+    long countByEventType(EventType eventType);
+}

--- a/backend-java/src/main/java/com/example/demo/service/AnalyticsService.java
+++ b/backend-java/src/main/java/com/example/demo/service/AnalyticsService.java
@@ -1,0 +1,37 @@
+package com.example.demo.service;
+
+import com.example.demo.model.AnalyticsEventEntity;
+import com.example.demo.model.AnalyticsEventEntity.EventType;
+import com.example.demo.repository.AnalyticsEventRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Service
+public class AnalyticsService {
+
+    private final AnalyticsEventRepository repository;
+
+    public AnalyticsService(AnalyticsEventRepository repository) {
+        this.repository = repository;
+    }
+
+    public void recordEvent(EventType type) {
+        AnalyticsEventEntity entity = new AnalyticsEventEntity();
+        entity.setEventType(type);
+        repository.save(entity);
+    }
+
+    public long countEvents(EventType type, Instant start, Instant end) {
+        if (start != null && end != null) {
+            return repository.countByEventTypeAndTimestampBetween(type, start, end);
+        }
+        if (start != null) {
+            return repository.countByEventTypeAndTimestampBetween(type, start, Instant.now());
+        }
+        if (end != null) {
+            return repository.countByEventTypeAndTimestampBetween(type, Instant.EPOCH, end);
+        }
+        return repository.countByEventType(type);
+    }
+}

--- a/backend-java/src/test/java/com/example/demo/controller/AnalyticsControllerTest.java
+++ b/backend-java/src/test/java/com/example/demo/controller/AnalyticsControllerTest.java
@@ -1,0 +1,60 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.AnalyticsEventEntity.EventType;
+import com.example.demo.service.AnalyticsService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AnalyticsController.class)
+class AnalyticsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AnalyticsService analyticsService;
+
+    @Test
+    void getAnalyticsReturnsCounts() throws Exception {
+        when(analyticsService.countEvents(EventType.GUEST_LOGIN, null, null)).thenReturn(1L);
+        when(analyticsService.countEvents(EventType.USER_SIGNUP, null, null)).thenReturn(2L);
+        when(analyticsService.countEvents(EventType.CV_DOWNLOAD, null, null)).thenReturn(3L);
+        when(analyticsService.countEvents(EventType.COVERLETTER_DOWNLOAD, null, null)).thenReturn(4L);
+
+        mockMvc.perform(get("/api/analytics"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.guestLogins").value(1L))
+                .andExpect(jsonPath("$.signups").value(2L))
+                .andExpect(jsonPath("$.cvDownloads").value(3L))
+                .andExpect(jsonPath("$.coverletterDownloads").value(4L));
+    }
+
+    @Test
+    void getAnalyticsWithRangePassesDates() throws Exception {
+        Instant start = Instant.parse("2024-01-01T00:00:00Z");
+        Instant end = Instant.parse("2024-01-02T00:00:00Z");
+        when(analyticsService.countEvents(any(), any(), any())).thenReturn(0L);
+
+        mockMvc.perform(get("/api/analytics")
+                        .param("start", start.toString())
+                        .param("end", end.toString()))
+                .andExpect(status().isOk());
+
+        verify(analyticsService).countEvents(EventType.GUEST_LOGIN, start, end);
+        verify(analyticsService).countEvents(EventType.USER_SIGNUP, start, end);
+        verify(analyticsService).countEvents(EventType.CV_DOWNLOAD, start, end);
+        verify(analyticsService).countEvents(EventType.COVERLETTER_DOWNLOAD, start, end);
+    }
+}

--- a/backend-java/src/test/java/com/example/demo/controller/DocumentControllerTest.java
+++ b/backend-java/src/test/java/com/example/demo/controller/DocumentControllerTest.java
@@ -2,6 +2,7 @@ package com.example.demo.controller;
 
 import com.example.demo.model.DocumentEntity;
 import com.example.demo.repository.DocumentRepository;
+import com.example.demo.service.AnalyticsService;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +32,9 @@ class DocumentControllerTest {
 
     @MockBean
     private DocumentRepository documentRepository;
+
+    @MockBean
+    private AnalyticsService analyticsService;
 
     @Test
     void getAllDocumentsReturnsList() throws Exception {

--- a/backend-java/src/test/java/com/example/demo/service/AnalyticsServiceTest.java
+++ b/backend-java/src/test/java/com/example/demo/service/AnalyticsServiceTest.java
@@ -1,0 +1,45 @@
+package com.example.demo.service;
+
+import com.example.demo.model.AnalyticsEventEntity;
+import com.example.demo.model.AnalyticsEventEntity.EventType;
+import com.example.demo.repository.AnalyticsEventRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class AnalyticsServiceTest {
+
+    @Autowired
+    private AnalyticsEventRepository repository;
+
+    @Test
+    void recordEventPersistsEntity() {
+        AnalyticsService service = new AnalyticsService(repository);
+        service.recordEvent(EventType.USER_SIGNUP);
+
+        assertThat(repository.count()).isEqualTo(1);
+        AnalyticsEventEntity saved = repository.findAll().get(0);
+        assertThat(saved.getEventType()).isEqualTo(EventType.USER_SIGNUP);
+        assertThat(saved.getTimestamp()).isNotNull();
+    }
+
+    @Test
+    void countEventsWithinRangeReturnsCorrectNumber() {
+        Instant base = Instant.parse("2024-01-01T00:00:00Z");
+        repository.save(new AnalyticsEventEntity(EventType.CV_DOWNLOAD, base));
+        repository.save(new AnalyticsEventEntity(EventType.CV_DOWNLOAD, base.plus(2, ChronoUnit.DAYS)));
+        repository.save(new AnalyticsEventEntity(EventType.CV_DOWNLOAD, base.plus(4, ChronoUnit.DAYS)));
+
+        AnalyticsService service = new AnalyticsService(repository);
+        long count = service.countEvents(EventType.CV_DOWNLOAD,
+                base.plus(1, ChronoUnit.DAYS),
+                base.plus(3, ChronoUnit.DAYS));
+        assertThat(count).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Summary
- add analytics event entity, repository and service
- record login, signup and download events
- expose analytics counts via REST
- test analytics service and controller
- update existing document controller test

## Testing
- `./backend-java/gradlew -p backend-java test` *(fails: plugin download)*

------
https://chatgpt.com/codex/tasks/task_e_68781cc7bd948322853cd66e09884527