### PR TITLE
Update user profile photo handling

### DIFF
--- a/frontend/src/components/layout/Header.js
+++ b/frontend/src/components/layout/Header.js
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import { useTheme } from '../../context/ThemeContext';
-import defaultPhoto from '../../Photo.jpg';
 import './Header.css';
 
 const Header = () => {
@@ -100,11 +99,13 @@ const Header = () => {
                     onClick={() => setShowProfileMenu(!showProfileMenu)}
                     aria-label="Open profile menu"
                   >
-                    <img
-                      src={user.profilePic || defaultPhoto}
-                      alt="Profile"
-                      className="profile-icon"
-                    />
+                    {user.profilePic && (
+                      <img
+                        src={user.profilePic}
+                        alt="Profile"
+                        className="profile-icon"
+                      />
+                    )}
                   </button>
                   {showProfileMenu && (
                     <ul className="profile-dropdown" role="menu">

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -16,7 +16,8 @@ export const AuthProvider = ({ children }) => {
       id: apiUser.id ? apiUser.id.toString() : Date.now().toString(),
       email: apiUser.email,
       name: apiUser.fullName,
-      role: apiUser.admin ? 'admin' : 'user'
+      role: apiUser.admin ? 'admin' : 'user',
+      profilePic: apiUser.profilePicture || null
     });
   };
 

--- a/frontend/src/pages/AccountPage.js
+++ b/frontend/src/pages/AccountPage.js
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useAuth } from '../context/AuthContext';
-import Photo from '../Photo.jpg';
 import './AccountPage.css';
 
 const AccountPage = () => {
@@ -10,7 +9,7 @@ const AccountPage = () => {
   const [email, setEmail] = useState(user?.email || '');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const [profilePic, setProfilePic] = useState(Photo);
+  const [profilePic, setProfilePic] = useState(user?.profilePic || null);
   const [error, setError] = useState('');
 
   const validatePassword = (pw) => {
@@ -43,7 +42,8 @@ const AccountPage = () => {
       id: user.id,
       email,
       fullName,
-      admin: user.role === 'admin'
+      admin: user.role === 'admin',
+      profilePicture: profilePic,
     });
     setEdit(false);
   };
@@ -64,7 +64,9 @@ const AccountPage = () => {
       <div className="container">
         {!edit ? (
           <div className="account-info">
-            <img src={profilePic} alt="Profile" className="profile-image" />
+            {profilePic && (
+              <img src={profilePic} alt="Profile" className="profile-image" />
+            )}
             <h2>{user.name}</h2>
             <p>{user.email}</p>
             <button className="button" onClick={() => setEdit(true)}>
@@ -137,3 +139,4 @@ const AccountPage = () => {
 };
 
 export default AccountPage;
+

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate, Navigate, Link } from 'react-router-dom';
 import { toast } from 'react-toastify';
-import { login as apiLogin, recordGuestLogin } from '../services/api';
+import { login as apiLogin, recordGuestLogin, fetchUserPhoto } from '../services/api';
 import { useAuth } from '../context/AuthContext';
 import './LoginPage.css';
 
@@ -33,7 +33,8 @@ const LoginPage = () => {
 
       try {
         const data = await apiLogin(email, password);
-        setAuthenticatedUser(data);
+        const photo = await fetchUserPhoto(data.id);
+        setAuthenticatedUser({ ...data, profilePicture: photo });
         const username = data.fullName || email.split('@')[0];
         let message = `Welcome, ${username}!`;
         if (data.lastLogin) {


### PR DESCRIPTION
## Summary
- extend `setAuthenticatedUser` to save `profilePic`
- fetch profile photo on login and save it in auth state
- show header avatar only when a photo is available
- use existing photo in account page and save it when updating profile