### PR TITLE
Add fallback robot icon

### DIFF
--- a/frontend/src/components/layout/Header.js
+++ b/frontend/src/components/layout/Header.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
+import { FaRobot } from 'react-icons/fa';
 import { useAuth } from '../../context/AuthContext';
 import { useTheme } from '../../context/ThemeContext';
 import './Header.css';
@@ -99,12 +100,15 @@ const Header = () => {
                     onClick={() => setShowProfileMenu(!showProfileMenu)}
                     aria-label="Open profile menu"
                   >
-                    {user.profilePic && (
+                    {user.profilePic ? (
                       <img
                         src={user.profilePic}
                         alt="Profile"
                         className="profile-icon"
+                        data-testid="profile-icon"
                       />
+                    ) : (
+                      <FaRobot className="profile-icon" data-testid="profile-icon" />
                     )}
                   </button>
                   {showProfileMenu && (

--- a/frontend/src/components/layout/Layout.test.js
+++ b/frontend/src/components/layout/Layout.test.js
@@ -29,6 +29,7 @@ describe('Header and Footer', () => {
 
     const profileButton = screen.getByRole('button', { name: /open profile menu/i });
     expect(profileButton).toBeInTheDocument();
+    expect(screen.getByTestId('profile-icon')).toBeInTheDocument();
 
     await userEvent.click(profileButton);
     expect(screen.getByRole('menu')).toBeInTheDocument();

--- a/frontend/src/pages/AccountPage.js
+++ b/frontend/src/pages/AccountPage.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { FaRobot } from 'react-icons/fa';
 import { useAuth } from '../context/AuthContext';
 import './AccountPage.css';
 
@@ -64,8 +65,15 @@ const AccountPage = () => {
       <div className="container">
         {!edit ? (
           <div className="account-info">
-            {profilePic && (
-              <img src={profilePic} alt="Profile" className="profile-image" />
+            {profilePic ? (
+              <img
+                src={profilePic}
+                alt="Profile"
+                className="profile-image"
+                data-testid="profile-image"
+              />
+            ) : (
+              <FaRobot className="profile-image" data-testid="profile-image" />
             )}
             <h2>{user.name}</h2>
             <p>{user.email}</p>


### PR DESCRIPTION
## Summary
- ensure profile actions always show an icon
- show fallback on the Account page if no image is provided
- test header profile icon when no image is stored

## Testing
- `npm test --prefix frontend --silent` *(fails: could not access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_687a245d880083228fbbc2912bb569f3